### PR TITLE
Use Catch2 v3 properly

### DIFF
--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -9,8 +9,8 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Cache package contents to a
 
 FetchContent_Declare(
   Nain4
-  GIT_REPOSITORY https://github.com/jacg/nain4.git
-  GIT_TAG        v0.0.1
+  GIT_REPOSITORY https://github.com/gonzaponte/nain4.git
+  GIT_TAG        04cac7ba64f3a832cd1e05ec0b0a8f73d1b0288d
   # make sure that no other nain4 installation is used
   OVERRIDE_FIND_PACKAGE
   SOURCE_SUBDIR nain4

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
             clang-tools
             cmake
             cmake-language-server
-            catch2
+            catch2_3
             just
             gnused # For hacking CMAKE_EXPORT stuff into CMakeLists.txt
             mdbook

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -57,19 +57,7 @@ set(Nain4_TESTS
 )
 
 # ----- Use Catch2 as C++ testing framework ---------------------------------
-set(FETCHCONTENT_UPDATES_DISCONNECTED ON
-    CACHE BOOL
-    "Cache package contents to avoid unnecessary downloads")
-
-include(FetchContent)
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.3.2
-  OVERRIDE_FIND_PACKAGE
-)
-FetchContent_MakeAvailable(Catch2)
-
+find_package(Catch2 REQUIRED)
 set(ALL_TEST_SOURCES
   test/catch2-main-test.cc
   # ${Nain4_SOURCES}
@@ -96,7 +84,6 @@ target_include_directories(
   $<INSTALL_INTERFACE:include>
 )
 
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)
 catch_discover_tests(nain4-tests)

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -57,7 +57,7 @@ set(Nain4_TESTS
 )
 
 # ----- Use Catch2 as C++ testing framework ---------------------------------
-find_package(Catch2 REQUIRED)
+find_package(Catch2 3 REQUIRED)
 set(ALL_TEST_SOURCES
   test/catch2-main-test.cc
   # ${Nain4_SOURCES}

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -57,7 +57,19 @@ set(Nain4_TESTS
 )
 
 # ----- Use Catch2 as C++ testing framework ---------------------------------
-find_package(Catch2 REQUIRED)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON
+    CACHE BOOL
+    "Cache package contents to avoid unnecessary downloads")
+
+include(FetchContent)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.3.2
+  OVERRIDE_FIND_PACKAGE
+)
+FetchContent_MakeAvailable(Catch2)
+
 set(ALL_TEST_SOURCES
   test/catch2-main-test.cc
   # ${Nain4_SOURCES}
@@ -84,6 +96,7 @@ target_include_directories(
   $<INSTALL_INTERFACE:include>
 )
 
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)
 catch_discover_tests(nain4-tests)

--- a/nain4/justfile
+++ b/nain4/justfile
@@ -20,7 +20,7 @@ test PATTERN *FLAGS: build
 		else
 			NPASSED=$((NPASSED+1))
 		fi
-	done < <(./nain4-tests {{PATTERN}} --list-test-names-only)
+	done < <(./nain4-tests {{PATTERN}} --list-tests --verbosity quiet)
 	if ! [ -z "$FAILED" ]; then
 		printf "\\033[91m===========================================================================\n"
 		printf "\\033[32m Passed $NPASSED tests, \\033[91m Failed $NFAILED\n\n"

--- a/nain4/test/catch2-main-test.cc
+++ b/nain4/test/catch2-main-test.cc
@@ -11,8 +11,8 @@
 #include <G4EmStandardPhysics_option4.hh>
 #include <G4OpticalPhysics.hh>
 
-#define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <fstream>
 #include <memory>

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -17,7 +17,11 @@
 #include <G4Material.hh>
 #include <G4Gamma.hh>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace Catch;
 
 // Many of the tests below check physical quantities. Dividing physical
 // quantities by their units gives raw numbers which are easily understandable

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -21,7 +21,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-using namespace Catch;
+using Catch::Approx;
 
 // Many of the tests below check physical quantities. Dividing physical
 // quantities by their units gives raw numbers which are easily understandable

--- a/nain4/test/trivial-full-app-test.cc
+++ b/nain4/test/trivial-full-app-test.cc
@@ -24,7 +24,8 @@
 
 
 #include <Randomize.hh>
-#include <catch2/catch.hpp>
+
+#include <catch2/catch_test_macros.hpp>
 
 #include <tuple>
 #include <algorithm>


### PR DESCRIPTION
Does what #21 did + addresses missed test failures.

One client-side test was failing. The issue was that `FetchContent` was coded to download tag `v0.0.1`, which uses Catch2 v2. However, the environment (which is set by the flake) contains Catch v3, which is not compatible. 

I've added a commit that forces the test to download this branch (with Catch2 v3). After demonstrating that this works, I propose we merge this pr, tag it with some version, and commit another change to the test file that points to this new tag.