### PR TITLE
Add n4app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Run client-side tests
         run: nix develop -c just test-client-side
 
+      - name: Run nain4 examples
+        run: nix develop -c just examples
+
       - name: Run G4 examples
         run: nix develop -c just g4-examples/run-examples-that-work

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         run: nix develop -c just test-client-side
 
       - name: Run nain4 examples
-        run: nix develop -c just examples
+        run: nix develop -c just test-examples
 
       - name: Run G4 examples
         run: nix develop -c just g4-examples/run-examples-that-work

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -4,5 +4,6 @@
 - [Tutorials](./tutorials.md)
 - [How-To Guides](./how-to.md)
   - [How to make `nain4` available in a `Geant4`/`cmake` project](./how-to/enable-nain4-in-cmake.md)
+  - [How to build a minimal `nain4` app](./how-to/build-a-minimal-nain4-app.md)
 - [Explanation](./explanation.md)
 - [Reference](./reference.md)

--- a/doc/src/how-to/build-a-minimal-nain4-app.md
+++ b/doc/src/how-to/build-a-minimal-nain4-app.md
@@ -17,17 +17,20 @@ In order to run a simulation we need to create a run manager:
 {{#include ../../../examples/n4app.cc:create_run_manager}}
 ```
 
-The run manager needs to be initialized with 4 attributes:
+The run manager needs to be initialized with 3 attributes:
 - A physics list
 - A geometry
-- A primary generator
 - A set of actions
 
+To build the action set we need to provide a primary generator action. Other actions are optional.
 Note that the physics list must be instantiated and given to the run manager before the primary generator is instantiated. We provide the run manager with these attributes:
+
 ```c++
 {{#include ../../../examples/n4app.cc:build_minimal_framework}}
 ```
+
 here, `my_geometry`, and `my_generator` are the two functions we need to provide to run our simulation:
+
 ```c++
 {{#include ../../../examples/n4app.cc:my_geometry}}
 

--- a/doc/src/how-to/build-a-minimal-nain4-app.md
+++ b/doc/src/how-to/build-a-minimal-nain4-app.md
@@ -2,18 +2,18 @@
 
 The most basic example of a nain4 app can be found in [examples/n4app.cc](../../../examples/n4app.cc). Here is the full file:
 
-```
+```c++
 {{#include ../../../examples/n4app.cc:full_file}}
 ```
 
 Now, let's split it into bite-sized portions. First we create a simple program that reads the number of events from CLI:
-```
+```c++
 {{#include ../../../examples/n4app.cc:pick_cli_arguments}}
 {{#include ../../../examples/n4app.cc:closing_bracket}}
 ```
 
 In order to run a simulation we need to create a run manager:
-```
+```c++
 {{#include ../../../examples/n4app.cc:create_run_manager}}
 ```
 
@@ -24,11 +24,11 @@ The run manager needs to be initialized with 4 attributes:
 - A set of actions
 
 Note that the physics list must be instantiated and given to the run manager before the primary generator is instantiated. We provide the run manager with these attributes:
-```
+```c++
 {{#include ../../../examples/n4app.cc:build_minimal_framework}}
 ```
 here, `my_physics_list`, `my_geometry`, and `my_generator` are the three functions we need to provide to run our simulation:
-```
+```c++
 {{#include ../../../examples/n4app.cc:my_physics_list}}
 
 {{#include ../../../examples/n4app.cc:my_geometry}}
@@ -37,16 +37,16 @@ here, `my_physics_list`, `my_geometry`, and `my_generator` are the three functio
 ```
 
 With this, our setup is ready, and we can start the simulation with
-```
+```c++
 {{#include ../../../examples/n4app.cc:run}}
 ```
 
 Don't forget to add the relevant includes
-```
+```c++
 {{#include ../../../examples/n4app.cc:includes}}
 ```
 
 and deleting the run_manager before exiting for proper memory deallocation.
-```
+```c++
 {{#include ../../../examples/n4app.cc:close_gracefully}}
 ```

--- a/doc/src/how-to/build-a-minimal-nain4-app.md
+++ b/doc/src/how-to/build-a-minimal-nain4-app.md
@@ -27,10 +27,8 @@ Note that the physics list must be instantiated and given to the run manager bef
 ```c++
 {{#include ../../../examples/n4app.cc:build_minimal_framework}}
 ```
-here, `my_physics_list`, `my_geometry`, and `my_generator` are the three functions we need to provide to run our simulation:
+here, `my_geometry`, and `my_generator` are the two functions we need to provide to run our simulation:
 ```c++
-{{#include ../../../examples/n4app.cc:my_physics_list}}
-
 {{#include ../../../examples/n4app.cc:my_geometry}}
 
 {{#include ../../../examples/n4app.cc:my_generator}}
@@ -46,7 +44,4 @@ Don't forget to add the relevant includes
 {{#include ../../../examples/n4app.cc:includes}}
 ```
 
-and deleting the run_manager before exiting for proper memory deallocation.
-```c++
-{{#include ../../../examples/n4app.cc:close_gracefully}}
-```
+To run this test type `just test-examples` from the top `nain4` directory.

--- a/doc/src/how-to/build-a-minimal-nain4-app.md
+++ b/doc/src/how-to/build-a-minimal-nain4-app.md
@@ -1,0 +1,52 @@
+# How to create a minimal nain4 app
+
+The most basic example of a nain4 app can be found in [examples/n4app.cc](../../../examples/n4app.cc). Here is the full file:
+
+```
+{{#include ../../../examples/n4app.cc:full_file}}
+```
+
+Now, let's split it into bite-sized portions. First we create a simple program that reads the number of events from CLI:
+```
+{{#include ../../../examples/n4app.cc:pick_cli_arguments}}
+{{#include ../../../examples/n4app.cc:closing_bracket}}
+```
+
+In order to run a simulation we need to create a run manager:
+```
+{{#include ../../../examples/n4app.cc:create_run_manager}}
+```
+
+The run manager needs to be initialized with 4 attributes:
+- A physics list
+- A geometry
+- A primary generator
+- A set of actions
+
+Note that the physics list must be instantiated and given to the run manager before the primary generator is instantiated. We provide the run manager with these attributes:
+```
+{{#include ../../../examples/n4app.cc:build_minimal_framework}}
+```
+here, `my_physics_list`, `my_geometry`, and `my_generator` are the three functions we need to provide to run our simulation:
+```
+{{#include ../../../examples/n4app.cc:my_physics_list}}
+
+{{#include ../../../examples/n4app.cc:my_geometry}}
+
+{{#include ../../../examples/n4app.cc:my_generator}}
+```
+
+With this, our setup is ready, and we can start the simulation with
+```
+{{#include ../../../examples/n4app.cc:run}}
+```
+
+Don't forget to add the relevant includes
+```
+{{#include ../../../examples/n4app.cc:includes}}
+```
+
+and deleting the run_manager before exiting for proper memory deallocation.
+```
+{{#include ../../../examples/n4app.cc:close_gracefully}}
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(n4app)
+
+set(Nain4_DIR "../install/lib/cmake/Nain4/")
+message(${Nain4_DIR})
+find_package(Nain4 REQUIRED)
+
+find_package(Geant4 REQUIRED)
+include(${Geant4_USE_FILE})
+
+add_executable(n4app n4app.cc)
+
+target_link_libraries(
+n4app
+PRIVATE
+Nain4
+${Geant4_LIBRARIES}
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.25)
 
 project(n4app)
 
+# ----- Generate compile_commands.json, unless otherwise instructed on CLI --
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+# ----- Ensure that standard C++ headers are found by clangd
+if(CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+endif()
+
 set(Nain4_DIR "../install/lib/cmake/Nain4/")
 message(${Nain4_DIR})
 find_package(Nain4 REQUIRED)

--- a/examples/justfile
+++ b/examples/justfile
@@ -1,5 +1,10 @@
 
 
+test-app:
+  just compile-app
+  just run-app 0 && just run-app 1
+
+
 compile-app:
   cmake -S . -B build
   cmake --build build
@@ -9,8 +14,3 @@ run-app N:
   #!/usr/bin/env sh
   ./build/n4app {{N}}
   exit $?
-
-
-test-app:
-  just compile-app
-  just run-app 0 && just run-app 1

--- a/examples/justfile
+++ b/examples/justfile
@@ -1,0 +1,16 @@
+
+
+compile-app:
+  cmake -S . -B build
+  cmake --build build
+
+
+run-app N:
+  #!/usr/bin/env sh
+  ./build/n4app {{N}}
+  exit $?
+
+
+test-app:
+  just compile-app
+  just run-app 0 && just run-app 1

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -53,7 +53,7 @@ G4VUserPhysicsList* my_physics_list() {
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
   if (argc != 2) {
-    std::cerr << "Wrong number of parameters: " << argc << std::endl;
+    std::cerr << "Wrong number of arguments: " << argc << std::endl;
     print_usage();
     std::exit(EXIT_FAILURE);
   }

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -1,0 +1,68 @@
+#include "nain4.hh"
+#include "g4-mandatory.hh"
+
+#include <G4RunManagerFactory.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4Event.hh>
+#include <G4Box.hh>
+#include <FTFP_BERT.hh>
+
+#include <stdlib.h>
+
+
+void print_usage() {
+  std::cout << "Usage:" << std::endl
+            << "./n4app <number of events>" << std::endl;
+}
+
+
+G4VPhysicalVolume* my_geometry() {
+  auto world_halfsize = 1 * m;
+
+  auto world = n4::volume<G4Box>( "world"
+                                , n4::material("G4_AIR")
+                                , world_halfsize, world_halfsize, world_halfsize);
+  return n4::place(world).now();
+}
+
+void my_generator(G4Event* event) {
+  auto geantino = n4::find_particle("geantino");
+  auto vertex   = new G4PrimaryVertex();
+  vertex->SetPrimary(new G4PrimaryParticle(geantino, 1, 0, 0));
+  event->AddPrimaryVertex(vertex);
+}
+
+G4VUserPhysicsList* my_physics_list() {
+  return new FTFP_BERT{0};
+}
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::cerr << "Wrong number of parameters: " << argc << std::endl;
+    print_usage();
+    return 1;
+  }
+
+  auto n_events = atoi(argv[1]);
+
+
+  auto* run_manager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
+
+  // Important! physics list has to be set before the generator!
+  run_manager -> SetUserInitialization(my_physics_list());
+
+  auto geometry  = new n4::geometry {my_geometry};
+  auto generator = new n4::generator{my_generator};
+  auto actions   = new n4::actions  {generator};
+
+  run_manager -> SetUserInitialization(geometry);
+  run_manager -> SetUserInitialization(actions);
+  run_manager -> Initialize();
+
+  run_manager -> BeamOn(n_events);
+
+  delete run_manager;
+
+  return 0;
+}

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -11,7 +11,7 @@
 #include <G4Box.hh>
 #include <FTFP_BERT.hh>
 
-#include <stdlib.h>
+#include <cstdlib>
 // ANCHOR_END: includes
 
 // ANCHOR: print_usage

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -3,10 +3,10 @@
 #include "nain4.hh"
 #include "g4-mandatory.hh"
 
-#include <G4SystemOfUnits.hh>
-#include <G4Event.hh> // handle to the event for primary generation of particles
-#include <G4Box.hh>
-#include <FTFP_BERT.hh> // physics list
+#include <G4SystemOfUnits.hh> // physical units such as `m` for metre
+#include <G4Event.hh>         // needed to inject primary particles into an event
+#include <G4Box.hh>           // for creating shapes in the geometry
+#include <FTFP_BERT.hh>       // our choice of physics list
 
 #include <cstdlib>
 // ANCHOR_END: includes

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -28,11 +28,9 @@ void verify_number_of_args(int argc){
 
 // ANCHOR: my_geometry
 auto my_geometry() {
-  auto world_halfsize = 1 * m;
-
-  auto world = n4::volume<G4Box>( "world"
-                                , n4::material("G4_AIR")
-                                , world_halfsize, world_halfsize, world_halfsize);
+  auto hl = 1 * m; // HALF-length of world volume
+  auto air = n4::material("G4_AIR");
+  auto world = n4::volume<G4Box>("world", air, hl, hl, hl);
   return n4::place(world).now();
 }
 // ANCHOR_END: my_geometry

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -12,15 +12,10 @@
 // ANCHOR_END: includes
 
 // ANCHOR: print_usage
-void print_usage() {
-  std::cout << "Usage:" << std::endl
-            << "./n4app <number of events>" << std::endl;
-}
-
 void verify_number_of_args(int argc){
   if (argc != 2) {
-    std::cerr << "Wrong number of arguments: " << argc << std::endl;
-    print_usage();
+    std::cerr << "Wrong number of arguments: " << argc
+              << "\nUsage:\n./n4app <number of events>" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 }
@@ -47,7 +42,6 @@ void my_generator(G4Event* event) {
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
   verify_number_of_args(argc);
-
   auto n_events = std::stoi(argv[1]);
   // ANCHOR_END: pick_cli_arguments
 

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
 
   // ANCHOR: create_run_manager
   auto run_manager = std::unique_ptr<G4RunManager>
-  {G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default)};
+  {G4RunManagerFactory::CreateRunManager(G4RunManagerType::SerialOnly)};
   // ANCHOR_END: create_run_manager
 
   // ANCHOR: build_minimal_framework

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -19,6 +19,14 @@ void print_usage() {
   std::cout << "Usage:" << std::endl
             << "./n4app <number of events>" << std::endl;
 }
+
+void verify_call_signature(int argc){
+  if (argc != 2) {
+    std::cerr << "Wrong number of arguments: " << argc << std::endl;
+    print_usage();
+    std::exit(EXIT_FAILURE);
+  }
+}
 // ANCHOR_END: print_usage
 
 
@@ -52,11 +60,7 @@ G4VUserPhysicsList* my_physics_list() {
 
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
-  if (argc != 2) {
-    std::cerr << "Wrong number of arguments: " << argc << std::endl;
-    print_usage();
-    std::exit(EXIT_FAILURE);
-  }
+  verify_call_signature(argc);
 
   auto n_events = std::stoi(argv[1]);
   // ANCHOR_END: pick_cli_arguments

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -3,8 +3,6 @@
 #include "nain4.hh"
 #include "g4-mandatory.hh"
 
-#include <G4RunManager.hh> // handle to the simulation framework
-#include <G4RunManagerFactory.hh> // generates the handle
 #include <G4SystemOfUnits.hh>
 #include <G4VPhysicalVolume.hh> // the output of our geometry
 #include <G4Event.hh> // handle to the event for primary generation of particles
@@ -60,8 +58,7 @@ int main(int argc, char* argv[]) {
   // ANCHOR_END: pick_cli_arguments
 
   // ANCHOR: create_run_manager
-  auto run_manager = std::unique_ptr<G4RunManager>
-  {G4RunManagerFactory::CreateRunManager(G4RunManagerType::SerialOnly)};
+  auto run_manager = n4::run_manager();
   // ANCHOR_END: create_run_manager
 
   // ANCHOR: build_minimal_framework

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -38,8 +38,8 @@ G4VPhysicalVolume* my_geometry() {
 void my_generator(G4Event* event) {
   auto geantino = n4::find_particle("geantino");
   auto vertex   = new G4PrimaryVertex();
-  vertex->SetPrimary(new G4PrimaryParticle(geantino, 1, 0, 0));
-  event->AddPrimaryVertex(vertex);
+  vertex -> SetPrimary(new G4PrimaryParticle(geantino, 1, 0, 0));
+  event  -> AddPrimaryVertex(vertex);
 }
 // ANCHOR_END: my_generator
 

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -4,7 +4,6 @@
 #include "g4-mandatory.hh"
 
 #include <G4SystemOfUnits.hh>
-#include <G4VPhysicalVolume.hh> // the output of our geometry
 #include <G4Event.hh> // handle to the event for primary generation of particles
 #include <G4Box.hh>
 #include <FTFP_BERT.hh> // physics list
@@ -29,7 +28,7 @@ void verify_call_signature(int argc){
 
 
 // ANCHOR: my_geometry
-G4VPhysicalVolume* my_geometry() {
+auto my_geometry() {
   auto world_halfsize = 1 * m;
 
   auto world = n4::volume<G4Box>( "world"

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -3,13 +3,13 @@
 #include "nain4.hh"
 #include "g4-mandatory.hh"
 
-#include <G4RunManager.hh>
-#include <G4RunManagerFactory.hh>
+#include <G4RunManager.hh> // handle to the simulation framework
+#include <G4RunManagerFactory.hh> // generates the handle
 #include <G4SystemOfUnits.hh>
-#include <G4VPhysicalVolume.hh>
-#include <G4Event.hh>
+#include <G4VPhysicalVolume.hh> // the output of our geometry
+#include <G4Event.hh> // handle to the event for primary generation of particles
 #include <G4Box.hh>
-#include <FTFP_BERT.hh>
+#include <FTFP_BERT.hh> // physics list
 
 #include <cstdlib>
 // ANCHOR_END: includes

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
   if (argc != 2) {
     std::cerr << "Wrong number of parameters: " << argc << std::endl;
     print_usage();
-    return 1;
+    std::exit(EXIT_FAILURE);
   }
 
   auto n_events = atoi(argv[1]);
@@ -86,7 +86,6 @@ int main(int argc, char* argv[]) {
   // ANCHOR_END: close_gracefully
 
 // ANCHOR: closing_bracket
-  return 0;
 }
 // ANCHOR_END: closing_bracket
 // ANCHOR_END: full_file

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -17,7 +17,7 @@ void print_usage() {
             << "./n4app <number of events>" << std::endl;
 }
 
-void verify_call_signature(int argc){
+void verify_number_of_args(int argc){
   if (argc != 2) {
     std::cerr << "Wrong number of arguments: " << argc << std::endl;
     print_usage();
@@ -51,7 +51,7 @@ void my_generator(G4Event* event) {
 
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
-  verify_call_signature(argc);
+  verify_number_of_args(argc);
 
   auto n_events = std::stoi(argv[1]);
   // ANCHOR_END: pick_cli_arguments

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -1,3 +1,5 @@
+// ANCHOR: full_file
+// ANCHOR: includes
 #include "nain4.hh"
 #include "g4-mandatory.hh"
 
@@ -9,14 +11,17 @@
 #include <FTFP_BERT.hh>
 
 #include <stdlib.h>
+// ANCHOR_END: includes
 
-
+// ANCHOR: print_usage
 void print_usage() {
   std::cout << "Usage:" << std::endl
             << "./n4app <number of events>" << std::endl;
 }
+// ANCHOR_END: print_usage
 
 
+// ANCHOR: my_geometry
 G4VPhysicalVolume* my_geometry() {
   auto world_halfsize = 1 * m;
 
@@ -25,18 +30,26 @@ G4VPhysicalVolume* my_geometry() {
                                 , world_halfsize, world_halfsize, world_halfsize);
   return n4::place(world).now();
 }
+// ANCHOR_END: my_geometry
 
+
+// ANCHOR: my_generator
 void my_generator(G4Event* event) {
   auto geantino = n4::find_particle("geantino");
   auto vertex   = new G4PrimaryVertex();
   vertex->SetPrimary(new G4PrimaryParticle(geantino, 1, 0, 0));
   event->AddPrimaryVertex(vertex);
 }
+// ANCHOR_END: my_generator
 
+
+// ANCHOR: my_physics_list
 G4VUserPhysicsList* my_physics_list() {
   return new FTFP_BERT{0};
 }
+// ANCHOR_END: my_physics_list
 
+// ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
   if (argc != 2) {
     std::cerr << "Wrong number of parameters: " << argc << std::endl;
@@ -45,10 +58,13 @@ int main(int argc, char* argv[]) {
   }
 
   auto n_events = atoi(argv[1]);
+  // ANCHOR_END: pick_cli_arguments
 
-
+  // ANCHOR: create_run_manager
   auto* run_manager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
+  // ANCHOR_END: create_run_manager
 
+  // ANCHOR: build_minimal_framework
   // Important! physics list has to be set before the generator!
   run_manager -> SetUserInitialization(my_physics_list());
 
@@ -59,10 +75,18 @@ int main(int argc, char* argv[]) {
   run_manager -> SetUserInitialization(geometry);
   run_manager -> SetUserInitialization(actions);
   run_manager -> Initialize();
+  // ANCHOR_END: build_minimal_framework
 
+  // ANCHOR: run
   run_manager -> BeamOn(n_events);
+  // ANCHOR_END: run
 
+  // ANCHOR: close_gracefully
   delete run_manager;
+  // ANCHOR_END: close_gracefully
 
+// ANCHOR: closing_bracket
   return 0;
 }
+// ANCHOR_END: closing_bracket
+// ANCHOR_END: full_file

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -26,7 +26,6 @@ void verify_number_of_args(int argc){
 }
 // ANCHOR_END: print_usage
 
-
 // ANCHOR: my_geometry
 auto my_geometry() {
   auto world_halfsize = 1 * m;
@@ -38,7 +37,6 @@ auto my_geometry() {
 }
 // ANCHOR_END: my_geometry
 
-
 // ANCHOR: my_generator
 void my_generator(G4Event* event) {
   auto geantino = n4::find_particle("geantino");
@@ -47,7 +45,6 @@ void my_generator(G4Event* event) {
   event  -> AddPrimaryVertex(vertex);
 }
 // ANCHOR_END: my_generator
-
 
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
@@ -71,7 +68,6 @@ int main(int argc, char* argv[]) {
   // ANCHOR: run
   run_manager -> BeamOn(n_events);
   // ANCHOR_END: run
-
 // ANCHOR: closing_bracket
 }
 // ANCHOR_END: closing_bracket

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -52,12 +52,6 @@ void my_generator(G4Event* event) {
 // ANCHOR_END: my_generator
 
 
-// ANCHOR: my_physics_list
-G4VUserPhysicsList* my_physics_list() {
-  return new FTFP_BERT{0};
-}
-// ANCHOR_END: my_physics_list
-
 // ANCHOR: pick_cli_arguments
 int main(int argc, char* argv[]) {
   verify_call_signature(argc);
@@ -72,14 +66,9 @@ int main(int argc, char* argv[]) {
 
   // ANCHOR: build_minimal_framework
   // Important! physics list has to be set before the generator!
-  run_manager -> SetUserInitialization(my_physics_list());
-
-  auto geometry  = new n4::geometry {my_geometry};
-  auto generator = new n4::generator{my_generator};
-  auto actions   = new n4::actions  {generator};
-
-  run_manager -> SetUserInitialization(geometry);
-  run_manager -> SetUserInitialization(actions);
+  run_manager -> SetUserInitialization(new FTFP_BERT{0}); // version 0
+  run_manager -> SetUserInitialization(new n4::geometry{my_geometry});
+  run_manager -> SetUserInitialization(new n4::actions {new n4::generator{my_generator}});
   run_manager -> Initialize();
   // ANCHOR_END: build_minimal_framework
 

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     std::exit(EXIT_FAILURE);
   }
 
-  auto n_events = atoi(argv[1]);
+  auto n_events = std::stoi(argv[1]);
   // ANCHOR_END: pick_cli_arguments
 
   // ANCHOR: create_run_manager

--- a/examples/n4app.cc
+++ b/examples/n4app.cc
@@ -3,6 +3,7 @@
 #include "nain4.hh"
 #include "g4-mandatory.hh"
 
+#include <G4RunManager.hh>
 #include <G4RunManagerFactory.hh>
 #include <G4SystemOfUnits.hh>
 #include <G4VPhysicalVolume.hh>
@@ -61,7 +62,8 @@ int main(int argc, char* argv[]) {
   // ANCHOR_END: pick_cli_arguments
 
   // ANCHOR: create_run_manager
-  auto* run_manager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
+  auto run_manager = std::unique_ptr<G4RunManager>
+  {G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default)};
   // ANCHOR_END: create_run_manager
 
   // ANCHOR: build_minimal_framework
@@ -80,10 +82,6 @@ int main(int argc, char* argv[]) {
   // ANCHOR: run
   run_manager -> BeamOn(n_events);
   // ANCHOR_END: run
-
-  // ANCHOR: close_gracefully
-  delete run_manager;
-  // ANCHOR_END: close_gracefully
 
 // ANCHOR: closing_bracket
 }

--- a/justfile
+++ b/justfile
@@ -4,5 +4,9 @@ test-nain4:
     just nain4/test-all
 
 
+test-examples:
+    just examples/
+
+
 test-client-side:
     just client_side_tests/test-all

--- a/nain4/justfile
+++ b/nain4/justfile
@@ -45,7 +45,7 @@ build: cmake
 cmake:
 	#!/usr/bin/env sh
 	cmake -S . -B build
-	cmake --build build -j
+	cmake --build build --target install -j
 
 
 clean:


### PR DESCRIPTION
A first go at #7. This includes an app that runs the most basic simulation imaginable (or close to). The app comes with its own `CMakeLists` and `justfile` for convenience. I've also added the corresponding documentation.

Notice that `nain4` has to be installed for the example to link against it. It can also be done with `FetchContent`, but I think the former option makes more sense in this context. Let me know if you think otherwise.