### PR TITLE
Use macros to avoid repetition of `n4::solid` members that store and set `x`, `y`, `z`, `r`, `phi`, `theta` etc. 

### DIFF
--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -29,6 +29,7 @@ enum class BOOL_OP { ADD, SUB, INT };
 
 struct boolean_shape;
 
+// ---- Base class for interfaces to G4VSolids --------------------------------------------------------
 struct shape {
   G4LogicalVolume*  volume(G4Material* material) const;
   n4::place          place(G4Material* material) const { return n4::place(volume(material)); }
@@ -55,7 +56,7 @@ protected:
   G4String                             name_;
 };
 
-
+// ---- Interface for constructing G4 boolean solids --------------------------------------------------
 struct boolean_shape : shape {
   friend shape;
   G4VSolid* solid() const override;
@@ -75,6 +76,8 @@ private:
 template<class S> boolean_shape shape::join (S shape){ return add      (shape); }
 template<class S> boolean_shape shape::sub  (S shape){ return subtract (shape); }
 template<class S> boolean_shape shape::inter(S shape){ return intersect(shape); }
+
+// ---- Macros for reuse of members and setters of orthogonal directions ------------------------------
 
 #define HAS_R(TYPE)                                          \
 public:                                                      \
@@ -108,7 +111,7 @@ private:                                                         \
   OPT_DOUBLE theta_delta_;                                       \
   const static constexpr G4D theta_full = 180 * deg;
 
-
+// ---- Interfaces for specific G4VSolids -------------------------------------------------------------
 struct box : shape {
   box(G4String name) : shape{name} {}
   box&      x(G4D l) { half_x_ = l / 2; return *this; }
@@ -152,7 +155,7 @@ private:
   G4D   half_z_;
 };
 
-
+// ---- Ensure that local macros don't leak out -------------------------------------------------------
 #undef G4D
 #undef OPT_DOUBLE
 #undef SENSITIVE

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -76,6 +76,15 @@ template<class S> boolean_shape shape::join (S shape){ return add      (shape); 
 template<class S> boolean_shape shape::sub  (S shape){ return subtract (shape); }
 template<class S> boolean_shape shape::inter(S shape){ return intersect(shape); }
 
+#define HAS_R(TYPE)                                          \
+public:                                                      \
+  TYPE& r_inner     (G4D x) { r_inner_ = x; return *this; }; \
+  TYPE& r           (G4D x) { r_outer_ = x; return *this; }; \
+  TYPE& r_delta     (G4D x) { r_delta_ = x; return *this; }; \
+private:                                                     \
+  OPT_DOUBLE r_inner_;                                       \
+  OPT_DOUBLE r_delta_;                                       \
+  OPT_DOUBLE r_outer_;
 
 struct box : shape {
   box(G4String name) : shape{name} {}
@@ -99,9 +108,8 @@ private:
 
 struct sphere : shape {
   sphere(G4String name) : shape{name} {}
-  sphere& r_inner     (G4D x) { r_inner_     = x; return *this; };
-  sphere& r           (G4D x) { r_outer_     = x; return *this; };
-  sphere& r_delta     (G4D x) { r_delta_     = x; return *this; };
+  HAS_R(sphere)
+public:
   sphere& phi_start   (G4D x) { phi_start_   = x; return *this; };
   sphere& phi_end     (G4D x) { phi_end_     = x; return *this; };
   sphere& phi_delta   (G4D x) { phi_delta_   = x; return *this; };
@@ -111,9 +119,6 @@ struct sphere : shape {
   SENSITIVE(sphere)
   G4VSolid* solid() const;
 private:
-  OPT_DOUBLE r_inner_;
-  OPT_DOUBLE r_delta_;
-  OPT_DOUBLE r_outer_;
   G4D   phi_start_   = 0;
   OPT_DOUBLE phi_end_;
   OPT_DOUBLE phi_delta_;
@@ -151,6 +156,7 @@ private:
 
 #undef OPT_DOUBLE
 #undef G4D
+#undef HAS_R
 
 }; // namespace nain4
 

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -18,12 +18,11 @@
 #include <optional>
 
 #define G4D G4double
+#define G4SensDet G4VSensitiveDetector
 
 namespace nain4 {
 
 #define OPT_DOUBLE std::optional<G4double>
-
-#define SENSITIVE(TYPE) TYPE& sensitive(G4VSensitiveDetector* s) { sd = s; return *this; }
 
 enum class BOOL_OP { ADD, SUB, INT };
 
@@ -33,7 +32,8 @@ struct boolean_shape;
 struct shape {
   G4LogicalVolume*  volume(G4Material* material) const;
   n4::place          place(G4Material* material) const { return n4::place(volume(material)); }
-  shape&             name (G4String    name    ) { name_ = name; return *this; }
+  shape&              name(G4String    name    ) { name_ = name; return *this; }
+  shape&         sensitive(G4SensDet*  s       ) { sd    = s   ; return *this; }
   virtual G4VSolid*  solid(                    ) const = 0;
   virtual ~shape() {}
 
@@ -124,7 +124,6 @@ struct box : shape {
   box& half_cube(G4double l) { return this -> half_xyz(l,l,l); }
   box&      xyz(G4D x, G4D y, G4D z) { return this ->     x(x).y(y).z(z); }
   box& half_xyz(G4D x, G4D y, G4D z) { return this -> xyz(x*2, y*2, z*2); }
-  SENSITIVE(box)
   G4Box* solid() const;
 private:
   G4D half_x_;
@@ -138,7 +137,6 @@ struct sphere : shape {
   HAS_PHI  (sphere)
   HAS_THETA(sphere)
 public:
-  SENSITIVE(sphere)
   G4VSolid* solid() const;
 };
 
@@ -149,7 +147,6 @@ struct tubs : shape {
 public:
   tubs& half_z   (G4D x) { half_z_    = x  ; return *this; };
   tubs& z        (G4D x) { half_z_    = x/2; return *this; };
-  SENSITIVE(tubs)
   G4Tubs* solid() const;
 private:
   G4D   half_z_;
@@ -157,8 +154,8 @@ private:
 
 // ---- Ensure that local macros don't leak out -------------------------------------------------------
 #undef G4D
+#undef G4SensDet
 #undef OPT_DOUBLE
-#undef SENSITIVE
 #undef HAS_R
 #undef HAS_PHI
 #undef HAS_THETA

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -86,6 +86,17 @@ private:                                                     \
   OPT_DOUBLE r_delta_;                                       \
   OPT_DOUBLE r_outer_;
 
+#define HAS_PHI(TYPE)                                            \
+public:                                                          \
+  TYPE& phi_start   (G4D x) { phi_start_   = x; return *this; }; \
+  TYPE& phi_end     (G4D x) { phi_end_     = x; return *this; }; \
+  TYPE& phi_delta   (G4D x) { phi_delta_   = x; return *this; }; \
+private:                                                         \
+  G4D        phi_start_ = 0;                                     \
+  OPT_DOUBLE phi_end_;                                           \
+  OPT_DOUBLE phi_delta_;                                         \
+  const static constexpr G4D phi_full = 360 * deg;
+
 struct box : shape {
   box(G4String name) : shape{name} {}
   box&      x(G4D l) { half_x_ = l / 2; return *this; }
@@ -108,50 +119,39 @@ private:
 
 struct sphere : shape {
   sphere(G4String name) : shape{name} {}
-  HAS_R(sphere)
+  HAS_R  (sphere)
+  HAS_PHI(sphere)
 public:
-  sphere& phi_start   (G4D x) { phi_start_   = x; return *this; };
-  sphere& phi_end     (G4D x) { phi_end_     = x; return *this; };
-  sphere& phi_delta   (G4D x) { phi_delta_   = x; return *this; };
   sphere& theta_start (G4D x) { theta_start_ = x; return *this; };
   sphere& theta_end   (G4D x) { theta_end_   = x; return *this; };
   sphere& theta_delta (G4D x) { theta_delta_ = x; return *this; };
   SENSITIVE(sphere)
   G4VSolid* solid() const;
 private:
-  G4D   phi_start_   = 0;
-  OPT_DOUBLE phi_end_;
-  OPT_DOUBLE phi_delta_;
   G4D   theta_start_ = 0;
   OPT_DOUBLE theta_end_;
   OPT_DOUBLE theta_delta_;
-  const static constexpr G4D   phi_full = 360 * deg;
   const static constexpr G4D theta_full = 180 * deg;
 };
 
 struct tubs : shape {
   tubs(G4String name) : shape{name} {}
-  HAS_R(tubs)
+  HAS_R  (tubs)
+  HAS_PHI(tubs)
 public:
-  tubs& phi_start(G4D x) { phi_start_ = x  ; return *this; };
-  tubs& phi_end  (G4D x) { phi_end_   = x  ; return *this; };
-  tubs& phi_delta(G4D x) { phi_delta_ = x  ; return *this; };
   tubs& half_z   (G4D x) { half_z_    = x  ; return *this; };
   tubs& z        (G4D x) { half_z_    = x/2; return *this; };
   SENSITIVE(tubs)
   G4Tubs* solid() const;
 private:
-  G4D   phi_start_ = 0;
-  OPT_DOUBLE phi_end_;
-  OPT_DOUBLE phi_delta_;
   G4D   half_z_;
-  const static constexpr G4D phi_full = 360 * deg;
 };
 
 
 #undef OPT_DOUBLE
 #undef G4D
 #undef HAS_R
+#undef HAS_PHI
 
 }; // namespace nain4
 

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -97,6 +97,18 @@ private:                                                         \
   OPT_DOUBLE phi_delta_;                                         \
   const static constexpr G4D phi_full = 360 * deg;
 
+#define HAS_THETA(TYPE)                                          \
+public:                                                          \
+  TYPE& theta_start (G4D x) { theta_start_ = x; return *this; }; \
+  TYPE& theta_end   (G4D x) { theta_end_   = x; return *this; }; \
+  TYPE& theta_delta (G4D x) { theta_delta_ = x; return *this; }; \
+private:                                                         \
+  G4D   theta_start_ = 0;                                        \
+  OPT_DOUBLE theta_end_;                                         \
+  OPT_DOUBLE theta_delta_;                                       \
+  const static constexpr G4D theta_full = 180 * deg;
+
+
 struct box : shape {
   box(G4String name) : shape{name} {}
   box&      x(G4D l) { half_x_ = l / 2; return *this; }
@@ -119,19 +131,12 @@ private:
 
 struct sphere : shape {
   sphere(G4String name) : shape{name} {}
-  HAS_R  (sphere)
-  HAS_PHI(sphere)
+  HAS_R    (sphere)
+  HAS_PHI  (sphere)
+  HAS_THETA(sphere)
 public:
-  sphere& theta_start (G4D x) { theta_start_ = x; return *this; };
-  sphere& theta_end   (G4D x) { theta_end_   = x; return *this; };
-  sphere& theta_delta (G4D x) { theta_delta_ = x; return *this; };
   SENSITIVE(sphere)
   G4VSolid* solid() const;
-private:
-  G4D   theta_start_ = 0;
-  OPT_DOUBLE theta_end_;
-  OPT_DOUBLE theta_delta_;
-  const static constexpr G4D theta_full = 180 * deg;
 };
 
 struct tubs : shape {
@@ -152,6 +157,7 @@ private:
 #undef G4D
 #undef HAS_R
 #undef HAS_PHI
+#undef HAS_THETA
 
 }; // namespace nain4
 

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -132,18 +132,21 @@ public:                                                  \
 private:                                                 \
   G4D half_z_;
 
+#define HAS_XYZ(TYPE)                                                        \
+  HAS_X(TYPE)                                                                \
+  HAS_Y(TYPE)                                                                \
+  HAS_Z(TYPE)                                                                \
+public:                                                                      \
+  TYPE&      xyz(G4D x, G4D y, G4D z) { return this ->     x(x).y(y).z(z); } \
+  TYPE& half_xyz(G4D x, G4D y, G4D z) { return this -> xyz(x*2, y*2, z*2); }
 
 // ---- Interfaces for specific G4VSolids -------------------------------------------------------------
 struct box : shape {
   box(G4String name) : shape{name} {}
-  HAS_X(box)
-  HAS_Y(box)
-  HAS_Z(box)
+  HAS_XYZ(box)
 public:
   box&      cube(G4double l) { return this ->      xyz(l,l,l); }
   box& half_cube(G4double l) { return this -> half_xyz(l,l,l); }
-  box&      xyz(G4D x, G4D y, G4D z) { return this ->     x(x).y(y).z(z); }
-  box& half_xyz(G4D x, G4D y, G4D z) { return this -> xyz(x*2, y*2, z*2); }
   G4Box* solid() const;
 };
 
@@ -178,6 +181,7 @@ private:
 #undef HAS_X
 #undef HAS_Y
 #undef HAS_Z
+#undef HAS_XYZ
 
 }; // namespace nain4
 

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -118,24 +118,33 @@ public:                                                  \
 private:                                                 \
   G4D half_x_;
 
+#define HAS_Y(TYPE)                                      \
+public:                                                  \
+  TYPE&      y(G4D l) { half_y_ = l / 2; return *this; } \
+  TYPE& half_y(G4D l) { half_y_ = l    ; return *this; } \
+private:                                                 \
+  G4D half_y_;
+
+#define HAS_Z(TYPE)                                      \
+public:                                                  \
+  TYPE&      z(G4D l) { half_z_ = l / 2; return *this; } \
+  TYPE& half_z(G4D l) { half_z_ = l    ; return *this; } \
+private:                                                 \
+  G4D half_z_;
+
 
 // ---- Interfaces for specific G4VSolids -------------------------------------------------------------
 struct box : shape {
   box(G4String name) : shape{name} {}
   HAS_X(box)
+  HAS_Y(box)
+  HAS_Z(box)
 public:
-  box&      y(G4D l) { half_y_ = l / 2; return *this; }
-  box&      z(G4D l) { half_z_ = l / 2; return *this; }
-  box& half_y(G4D l) { half_y_ = l    ; return *this; }
-  box& half_z(G4D l) { half_z_ = l    ; return *this; }
   box&      cube(G4double l) { return this ->      xyz(l,l,l); }
   box& half_cube(G4double l) { return this -> half_xyz(l,l,l); }
   box&      xyz(G4D x, G4D y, G4D z) { return this ->     x(x).y(y).z(z); }
   box& half_xyz(G4D x, G4D y, G4D z) { return this -> xyz(x*2, y*2, z*2); }
   G4Box* solid() const;
-private:
-  G4D half_y_;
-  G4D half_z_;
 };
 
 struct sphere : shape {
@@ -167,6 +176,8 @@ private:
 #undef HAS_PHI
 #undef HAS_THETA
 #undef HAS_X
+#undef HAS_Y
+#undef HAS_Z
 
 }; // namespace nain4
 

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -153,8 +153,9 @@ private:
 };
 
 
-#undef OPT_DOUBLE
 #undef G4D
+#undef OPT_DOUBLE
+#undef SENSITIVE
 #undef HAS_R
 #undef HAS_PHI
 #undef HAS_THETA

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -163,12 +163,9 @@ struct tubs : shape {
   tubs(G4String name) : shape{name} {}
   HAS_R  (tubs)
   HAS_PHI(tubs)
+  HAS_Z  (tubs)
 public:
-  tubs& half_z   (G4D x) { half_z_    = x  ; return *this; };
-  tubs& z        (G4D x) { half_z_    = x/2; return *this; };
   G4Tubs* solid() const;
-private:
-  G4D   half_z_;
 };
 
 // ---- Ensure that local macros don't leak out -------------------------------------------------------

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -131,10 +131,8 @@ private:
 
 struct tubs : shape {
   tubs(G4String name) : shape{name} {}
-
-  tubs& r_inner  (G4D x) { r_inner_   = x  ; return *this; };
-  tubs& r        (G4D x) { r_outer_   = x  ; return *this; };
-  tubs& r_delta  (G4D x) { r_delta_   = x  ; return *this; };
+  HAS_R(tubs)
+public:
   tubs& phi_start(G4D x) { phi_start_ = x  ; return *this; };
   tubs& phi_end  (G4D x) { phi_end_   = x  ; return *this; };
   tubs& phi_delta(G4D x) { phi_delta_ = x  ; return *this; };
@@ -143,9 +141,6 @@ struct tubs : shape {
   SENSITIVE(tubs)
   G4Tubs* solid() const;
 private:
-  OPT_DOUBLE r_inner_;
-  OPT_DOUBLE r_delta_;
-  OPT_DOUBLE r_outer_;
   G4D   phi_start_ = 0;
   OPT_DOUBLE phi_end_;
   OPT_DOUBLE phi_delta_;

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -111,13 +111,21 @@ private:                                                         \
   OPT_DOUBLE theta_delta_;                                       \
   const static constexpr G4D theta_full = 180 * deg;
 
+#define HAS_X(TYPE)                                      \
+public:                                                  \
+  TYPE&      x(G4D l) { half_x_ = l / 2; return *this; } \
+  TYPE& half_x(G4D l) { half_x_ = l    ; return *this; } \
+private:                                                 \
+  G4D half_x_;
+
+
 // ---- Interfaces for specific G4VSolids -------------------------------------------------------------
 struct box : shape {
   box(G4String name) : shape{name} {}
-  box&      x(G4D l) { half_x_ = l / 2; return *this; }
+  HAS_X(box)
+public:
   box&      y(G4D l) { half_y_ = l / 2; return *this; }
   box&      z(G4D l) { half_z_ = l / 2; return *this; }
-  box& half_x(G4D l) { half_x_ = l    ; return *this; }
   box& half_y(G4D l) { half_y_ = l    ; return *this; }
   box& half_z(G4D l) { half_z_ = l    ; return *this; }
   box&      cube(G4double l) { return this ->      xyz(l,l,l); }
@@ -126,7 +134,6 @@ struct box : shape {
   box& half_xyz(G4D x, G4D y, G4D z) { return this -> xyz(x*2, y*2, z*2); }
   G4Box* solid() const;
 private:
-  G4D half_x_;
   G4D half_y_;
   G4D half_z_;
 };
@@ -159,6 +166,7 @@ private:
 #undef HAS_R
 #undef HAS_PHI
 #undef HAS_THETA
+#undef HAS_X
 
 }; // namespace nain4
 


### PR DESCRIPTION
If you're happy with this, go ahead and merge.