### PR TITLE
Implement `n4::trd`

### DIFF
--- a/nain4/n4-volumes.cc
+++ b/nain4/n4-volumes.cc
@@ -93,6 +93,8 @@ G4Cons* cons::solid() const {
   return new G4Cons{name_, r1_inner, r1_outer, r2_inner, r2_outer, half_z_, phi_start_, phi_delta};
 }
 
+G4Trd* trd::solid() const { return new G4Trd(name_, half_x1_, half_x2_, half_y1_, half_y2_, half_z_); }
+
 G4LogicalVolume* shape::volume(G4Material* material) const {
   auto vol = n4::volume(solid(), material);
   if (sd.has_value()) { vol -> SetSensitiveDetector(sd.value()); }

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -10,6 +10,7 @@
 #include <G4Types.hh>
 #include <G4Box.hh>
 #include <G4Cons.hh>
+#include <G4Trd.hh>
 #include <G4VSolid.hh>
 #include <G4Sphere.hh>
 #include <G4Tubs.hh>
@@ -189,6 +190,14 @@ public:
   // 1e3 * G4GeometryTolerance::GetInstance() -> GetRadialTolerance(); which is one nm
   const static constexpr G4double eps = 1 * CLHEP::nm;
 };
+
+struct trd : shape {
+  COMMON(trd, G4Trd)
+  HAS_XY(trd, 1)
+  HAS_XY(trd, 2)
+  HAS_Z (trd,  )
+};
+
 
 // ---- Ensure that local macros don't leak out -------------------------------------------------------
 #undef G4D

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -131,6 +131,14 @@ public:                                                                \
 private:                                                               \
   G4D half_y ## N ## _;
 
+#define HAS_XY(TYPE, N)                                                     \
+  HAS_X(TYPE, N)                                                            \
+  HAS_Y(TYPE, N)                                                            \
+public:                                                                     \
+  TYPE&      xy ## N(G4D l) {      x ## N(l);      y ##N(l); return *this;} \
+  TYPE& half_xy ## N(G4D l) { half_x ## N(l); half_y ##N(l); return *this;}
+
+
 #define HAS_Z(TYPE, N)                                                  \
 public:                                                                 \
   TYPE&      z ## N (G4D l) { half_z ## N ## _ = l / 2; return *this; } \
@@ -193,6 +201,7 @@ public:
 #undef HAS_X
 #undef HAS_Y
 #undef HAS_Z
+#undef HAS_XY
 #undef HAS_XYZ
 
 }; // namespace nain4

--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -132,14 +132,6 @@ public:                                                                \
 private:                                                               \
   G4D half_y ## N ## _;
 
-#define HAS_XY(TYPE, N)                                                     \
-  HAS_X(TYPE, N)                                                            \
-  HAS_Y(TYPE, N)                                                            \
-public:                                                                     \
-  TYPE&      xy ## N(G4D l) {      x ## N(l);      y ##N(l); return *this;} \
-  TYPE& half_xy ## N(G4D l) { half_x ## N(l); half_y ##N(l); return *this;}
-
-
 #define HAS_Z(TYPE, N)                                                  \
 public:                                                                 \
   TYPE&      z ## N (G4D l) { half_z ## N ## _ = l / 2; return *this; } \
@@ -193,9 +185,16 @@ public:
 
 struct trd : shape {
   COMMON(trd, G4Trd)
-  HAS_XY(trd, 1)
-  HAS_XY(trd, 2)
+  HAS_X (trd, 1)
+  HAS_X (trd, 2)
+  HAS_Y (trd, 1)
+  HAS_Y (trd, 2)
   HAS_Z (trd,  )
+public:
+  trd&      xy1(G4D l) {      x1(l);      y1(l); return *this;}
+  trd&      xy2(G4D l) {      x2(l);      y2(l); return *this;}
+  trd& half_xy1(G4D l) { half_x1(l); half_y1(l); return *this;}
+  trd& half_xy2(G4D l) { half_x2(l); half_y2(l); return *this;}
 };
 
 
@@ -210,7 +209,6 @@ struct trd : shape {
 #undef HAS_X
 #undef HAS_Y
 #undef HAS_Z
-#undef HAS_XY
 #undef HAS_XYZ
 
 }; // namespace nain4

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -592,15 +592,15 @@ TEST_CASE("nain trd", "[nain][trd]") {
   auto xc = 7 * m;
   auto yc = 8 * m;
   auto zc = 9 * m;
-  auto trd_h = n4::trd("trd_h" ).half_x1(lx1/2).half_y1(ly1/2).half_x2(lx2/2).half_y2(ly2/2).half_z(lz/2).solid();
-  auto trd_s = n4::trd("trd_s" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).solid();
-  auto trd_l = n4::trd("trd_l" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).volume(water);
-  auto trd_p = n4::trd("trd_p" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).place (water).at(xc, yc, zc).now();
+  auto trd_h = n4::trd("trd_h").half_x1(lx1/2).half_y1(ly1/2).half_x2(lx2/2).half_y2(ly2/2).half_z(lz/2).solid();
+  auto trd_s = n4::trd("trd_s")     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).solid();
+  auto trd_l = n4::trd("trd_l")     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).volume(water);
+  auto trd_p = n4::trd("trd_p")     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).place (water).at(xc, yc, zc).now();
 
   auto lxy1 = 10 * m;
   auto lxy2 = 11 * m;
   auto trd_xy      = n4::trd("trd_xy").     xy1(lxy1  ).     xy2(lxy2).z(lz).solid();
-  auto trd_half_xy  =n4::trd("trd_xy").half_xy1(lxy1/2).half_xy2(lxy2).z(lz).solid();
+  auto trd_half_xy = n4::trd("trd_xy").half_xy1(lxy1/2).half_xy2(lxy2).z(lz).solid();
 
   CHECK(trd_xy      -> GetXHalfLength1()   ==   trd_xy      -> GetYHalfLength1());
   CHECK(trd_xy      -> GetXHalfLength2()   ==   trd_xy      -> GetYHalfLength2());

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -582,6 +582,79 @@ TEST_CASE("nain cons", "[nain][cons]") {
 
 }
 
+TEST_CASE("nain trd", "[nain][trd]") {
+  // nain4::trd is a more convenient interface for constructing G4VSolids and
+  // G4LogicalVolumes based on G4Trd
+  auto water = nain4::material("G4_WATER"); auto density = water -> GetDensity();
+  auto lx1 = 1 * m; auto lx2 = 4 * m;
+  auto ly1 = 2 * m; auto ly2 = 5 * m;
+  auto lz  = 3 * m;
+  auto xc = 7 * m;
+  auto yc = 8 * m;
+  auto zc = 9 * m;
+  auto trd_h = n4::trd("trd_h" ).half_x1(lx1/2).half_y1(ly1/2).half_x2(lx2/2).half_y2(ly2/2).half_z(lz/2).solid();
+  auto trd_s = n4::trd("trd_s" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).solid();
+  auto trd_l = n4::trd("trd_l" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).volume(water);
+  auto trd_p = n4::trd("trd_p" )     .x1(lx1  )     .y1(ly1  ).     x2(lx2  )     .y2(ly2  )     .z(lz  ).place (water).at(xc, yc, zc).now();
+
+  auto lxy1 = 10 * m;
+  auto lxy2 = 11 * m;
+  auto trd_xy      = n4::trd("trd_xy").     xy1(lxy1  ).     xy2(lxy2).z(lz).solid();
+  auto trd_half_xy  =n4::trd("trd_xy").half_xy1(lxy1/2).half_xy2(lxy2).z(lz).solid();
+
+  CHECK(trd_xy      -> GetXHalfLength1()   ==   trd_xy      -> GetYHalfLength1());
+  CHECK(trd_xy      -> GetXHalfLength2()   ==   trd_xy      -> GetYHalfLength2());
+  CHECK(trd_xy      -> GetXHalfLength1()   !=   trd_xy      -> GetZHalfLength ());
+  CHECK(trd_xy      -> GetXHalfLength2()   !=   trd_xy      -> GetZHalfLength ());
+  CHECK(trd_half_xy -> GetXHalfLength1()   ==   trd_half_xy -> GetYHalfLength1());
+  CHECK(trd_half_xy -> GetXHalfLength2()   ==   trd_half_xy -> GetYHalfLength2());
+  CHECK(trd_half_xy -> GetXHalfLength1()   !=   trd_half_xy -> GetZHalfLength ());
+
+  auto dlx     = lx2 - lx1;
+  auto dly     = ly2 - ly1;
+  auto slx     = lx2 + lx1;
+  auto sly     = ly2 + ly1;
+
+  auto volume  = ( slx * sly + dlx * dly / 3 ) * lz / 4;
+  auto surface = lx1 * ly1 + lx2 * ly2
+               + sly * std::sqrt(lz*lz + dlx * dlx / 4)
+               + slx * std::sqrt(lz*lz + dly * dly / 4);
+
+  CHECK(trd_h -> GetCubicVolume() / m3 == trd_s -> GetCubicVolume() / m3);
+  CHECK(trd_h -> GetSurfaceArea() / m2 == trd_s -> GetSurfaceArea() / m2);
+
+  CHECK(trd_l -> TotalVolumeEntities() == 1);
+  CHECK(trd_l -> GetMass() / kg        == Approx(volume * density / kg));
+  CHECK(trd_l -> GetMaterial()         == water);
+  CHECK(trd_l -> GetName()             == "trd_l");
+
+  auto solid = trd_l -> GetSolid();
+  CHECK(solid -> GetCubicVolume() / m3 == Approx(volume  / m3));
+  CHECK(solid -> GetSurfaceArea() / m2 == Approx(surface / m2));
+  CHECK(solid -> GetName()             == "trd_l");
+
+  CHECK(trd_s -> GetCubicVolume() / m3 == solid -> GetCubicVolume() / m3);
+  CHECK(trd_s -> GetSurfaceArea() / m2 == solid -> GetSurfaceArea() / m2);
+  CHECK(trd_s -> GetName()             == "trd_s");
+
+  CHECK(trd_p -> GetTranslation() . x() / m == xc / m);
+  CHECK(trd_p -> GetTranslation() . y() / m == yc / m);
+  CHECK(trd_p -> GetTranslation() . z() / m == zc / m);
+
+  auto check_dimensions = [&] (auto trd) {
+    CHECK(trd -> GetXHalfLength1() / m  == lxy1 / 2 / m);
+    CHECK(trd -> GetYHalfLength1() / m  == lxy1 / 2 / m);
+    CHECK(trd -> GetXHalfLength2() / m  == lxy2 / 2 / m);
+    CHECK(trd -> GetYHalfLength2() / m  == lxy2 / 2 / m);
+    CHECK(trd -> GetZHalfLength () / m  == lz   / 2 / m);
+  };
+
+  check_dimensions(n4::trd("trd_xyz")     .     xy1(lxy1  ).     xy2(lxy2  ).z(lz).solid());
+  check_dimensions(n4::trd("trd_half_xyz").half_xy1(lxy1/2).half_xy2(lxy2/2).z(lz).solid());
+}
+
+
+
 TEST_CASE("nain volume", "[nain][volume]") {
   // nain4::volume produces objects with sensible sizes, masses, etc.
   auto water = nain4::material("G4_WATER"); auto density = water->GetDensity();


### PR DESCRIPTION
Progress on #25.

Implements and tests the n4 interface to construct a `G4Trd`, i.e. a generic trapezoid.

I first tried to avoid repetition using a macro, but I prefer the final version without it. The repeated lines were not that many and the result is more clear, IMO.

