### PR TITLE
Implement convenience rotation methods to `n4::place` and `n4::boolean_shape`

### DIFF
--- a/nain4/n4-volumes.hh
+++ b/nain4/n4-volumes.hh
@@ -63,6 +63,9 @@ struct boolean_shape : shape {
   friend shape;
   G4VSolid* solid() const override;
 
+  boolean_shape& rotate_x(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateX(delta);             return rotate(rot);}
+  boolean_shape& rotate_y(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateY(delta);             return rotate(rot);}
+  boolean_shape& rotate_z(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateZ(delta);             return rotate(rot);}
   boolean_shape& rotate(G4RotationMatrix& rot)    { transformation = HepGeom::Rotate3D{rot}      * transformation; return *this; }
   boolean_shape& at(double x, double y, double z) { transformation = HepGeom::Translate3D{x,y,z} * transformation; return *this; }
   boolean_shape& at(G4ThreeVector    p)           { return at(p.x(), p.y(), p.z()); }

--- a/nain4/nain4.hh
+++ b/nain4/nain4.hh
@@ -139,15 +139,18 @@ public:
   place(G4LogicalVolume* child)  : child(child ? make_optional(child) : nullopt) {}
   place(place const&) = default;
 
-  place& rotate(G4RotationMatrix& rot)     { transformation = HepGeom::Rotate3D{rot}      * transformation; return *this; }
-  place& at(double x, double y, double z)  { transformation = HepGeom::Translate3D{x,y,z} * transformation; return *this; }
-  place& at(G4ThreeVector    p)            { return at(p.x(), p.y(), p.z()); }
-  place& copy_no(int         n)            { copy_number = n      ; return *this; }
-  place& in(G4LogicalVolume* parent_)      { parent      = parent_; return *this; }
-  place& name(G4String       label_)       { label       = label_ ; return *this; }
+  place& rotate_x(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateX(delta);             return rotate(rot);}
+  place& rotate_y(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateY(delta);             return rotate(rot);}
+  place& rotate_z(double delta         )  { auto rot = G4RotationMatrix{}; rot.rotateZ(delta);             return rotate(rot);}
+  place& rotate  (G4RotationMatrix& rot)  { transformation = HepGeom::Rotate3D{rot}      * transformation; return *this;      }
+  place& at(double x, double y, double z) { transformation = HepGeom::Translate3D{x,y,z} * transformation; return *this;      }
+  place& at(G4ThreeVector    p)           { return at(p.x(), p.y(), p.z()); }
+  place& copy_no(int         n)           { copy_number = n      ; return *this; }
+  place& in(G4LogicalVolume* parent_)     { parent      = parent_; return *this; }
+  place& name(G4String       label_)      { label       = label_ ; return *this; }
 
-  place  clone() const                                            { return *this; }
-  G4PVPlacement* operator()()                                     { return now(); }
+  place  clone() const                                           { return *this; }
+  G4PVPlacement* operator()()                                    { return now(); }
   G4PVPlacement* now();
 
 private:

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -1171,9 +1171,9 @@ TEST_CASE("nain boolean rotation", "[nain][geometry][boolean][rotation]") {
   auto without_rot_xy = box_along_x.subtract(box_along_y).                 name("without_rot_xy").solid();
   auto without_rot_zx = box_along_z.subtract(box_along_x).                 name("without_rot_zx").solid();
   auto without_rot_yz = box_along_y.subtract(box_along_z).                 name("without_rot_yz").solid();
-  auto with_z_rot     = box_along_x.subtract(box_along_y).rotate_z(90*deg).name("with_z_rot"    ).solid();
-  auto with_y_rot     = box_along_z.subtract(box_along_x).rotate_y(90*deg).name("with_y_rot"    ).solid();
-  auto with_x_rot     = box_along_y.subtract(box_along_z).rotate_x(90*deg).name("with_x_rot"    ).solid();
+  auto    with_rot_z  = box_along_x.subtract(box_along_y).rotate_z(90*deg).name(   "with_rot_z" ).solid();
+  auto    with_rot_y  = box_along_z.subtract(box_along_x).rotate_y(90*deg).name(   "with_rot_y" ).solid();
+  auto    with_rot_x  = box_along_y.subtract(box_along_z).rotate_x(90*deg).name(   "with_rot_x" ).solid();
 
   // When rotated, the volumes overlap perfectly, resulting in a null volume
   // Cannot use GetCubicVolume because gives nonsense
@@ -1182,7 +1182,7 @@ TEST_CASE("nain boolean rotation", "[nain][geometry][boolean][rotation]") {
   CHECK( without_rot_xy -> EstimateCubicVolume(n, eps) >  0 );
   CHECK( without_rot_zx -> EstimateCubicVolume(n, eps) >  0 );
   CHECK( without_rot_yz -> EstimateCubicVolume(n, eps) >  0 );
-  CHECK( with_x_rot     -> EstimateCubicVolume(n, eps) == 0 );
-  CHECK( with_y_rot     -> EstimateCubicVolume(n, eps) == 0 );
-  CHECK( with_z_rot     -> EstimateCubicVolume(n, eps) == 0 );
+  CHECK(    with_rot_x  -> EstimateCubicVolume(n, eps) == 0 );
+  CHECK(    with_rot_y  -> EstimateCubicVolume(n, eps) == 0 );
+  CHECK(    with_rot_z  -> EstimateCubicVolume(n, eps) == 0 );
 }

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -30,7 +30,6 @@
 
 #include <cmath>
 #include <type_traits>
-#include <cmath>
 
 using Catch::Approx;
 

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -775,17 +775,6 @@ TEST_CASE("nain place", "[nain][place]") {
     CHECK(* xzrot -> GetObjectRotation() == rotmat(angle,     0, angle));
     CHECK(* yzrot -> GetObjectRotation() == rotmat(    0, angle, angle));
     CHECK(*xyzrot -> GetObjectRotation() == rotmat(angle, angle, angle));
-
-// Tried to measure tait-bryan angles, but it was too complicated and probably as clear
-// #define CHECK_ANGLE(PVP, METHOD, MOD)                            \
-//     CHECK(         std::fmod(PVP -> GetObjectRotation() -> METHOD(), MOD) == \
-//           Approx(  std::fmod(                      sign * angle, MOD))   \
-//          );
-
-//     CHECK_ANGLE(xrot, thetaZ, twopi)
-//     CHECK_ANGLE(yrot, thetaZ, twopi)
-//     CHECK_ANGLE(zrot, theta , twopi)
-// #undef  CHECK_ANGLE
   }
 }
 

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -1160,3 +1160,30 @@ TEST_CASE("nain boolean double intersect", "[nain][geometry][boolean][intersect]
   CHECKP(shape_short_ptr)
 #undef CHECKP
 }
+
+TEST_CASE("nain boolean rotation", "[nain][geometry][boolean][rotation]") {
+  auto l1  = 3*m;
+  auto l2  = 1*m;
+
+  auto box_along_x = n4::box("along-x").xyz(l2, l1, l1);
+  auto box_along_y = n4::box("along-y").xyz(l1, l2, l1);
+  auto box_along_z = n4::box("along-z").xyz(l1, l1, l2);
+
+  auto without_rot_xy = box_along_x.subtract(box_along_y).                 name("without_rot_xy").solid();
+  auto without_rot_zx = box_along_z.subtract(box_along_x).                 name("without_rot_zx").solid();
+  auto without_rot_yz = box_along_y.subtract(box_along_z).                 name("without_rot_yz").solid();
+  auto with_z_rot     = box_along_x.subtract(box_along_y).rotate_z(90*deg).name("with_z_rot"    ).solid();
+  auto with_y_rot     = box_along_z.subtract(box_along_x).rotate_y(90*deg).name("with_y_rot"    ).solid();
+  auto with_x_rot     = box_along_y.subtract(box_along_z).rotate_x(90*deg).name("with_x_rot"    ).solid();
+
+  // When rotated, the volumes overlap perfectly, resulting in a null volume
+  // Cannot use GetCubicVolume because gives nonsense
+  auto n   = 100000;
+  auto eps = 1e-3;
+  CHECK( without_rot_xy -> EstimateCubicVolume(n, eps) >  0 );
+  CHECK( without_rot_zx -> EstimateCubicVolume(n, eps) >  0 );
+  CHECK( without_rot_yz -> EstimateCubicVolume(n, eps) >  0 );
+  CHECK( with_x_rot     -> EstimateCubicVolume(n, eps) == 0 );
+  CHECK( with_y_rot     -> EstimateCubicVolume(n, eps) == 0 );
+  CHECK( with_z_rot     -> EstimateCubicVolume(n, eps) == 0 );
+}


### PR DESCRIPTION
Closes #39.

So far the syntax to rotate placed objects was a bit tedious:
```
auto rotation = G4RotationMatrix{};
rotation.rotateX(angle); // or Y or Z
// possibly other rotations
n4::place(something) // or some_shape.place(material)
  .rotate(rotation)
  .at(...)
  .now()
```

and similarly for boolean shapes:
```
some_shape.add(other_shape)
            .rotation(rotation)
            .at(...)
```

We now also offer `rotate_{x,y,z}` methods that can be concatenated like:
```
n4::place(something) // or shape.place(material)....
  .rotate_x(angle_x)
  .rotate_y(angle_y)
// ...
  .at(...).now()
```

with a similar syntax for boolean volumes:
```
some_shape.add(other_shape)
            .rotate_x(angle_x)
            .rotate_y(angle_y)
            .at(...)
```
