### PR TITLE
Raise an error if 0 or too many world volumes are created

### DIFF
--- a/nain4/n4_run_manager.cc
+++ b/nain4/n4_run_manager.cc
@@ -1,7 +1,39 @@
 #include "n4_run_manager.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4PhysicalVolumeStore.hh"
 
 namespace nain4 {
 
 run_manager* run_manager::rm_instance   = nullptr;
 bool         run_manager::create_called = false;
+
+
+void check_for_multiple_world_volumes() {
+  auto store = G4PhysicalVolumeStore::GetInstance();
+  std::vector<G4String> names{};
+
+  for (auto phys : *store) {
+    // Mother is nullptr when phys is the world volume
+    if (! phys -> GetMotherLogical()) {
+      names.push_back(phys -> GetName());
+    }
+  }
+  auto count = names.size();
+  if (count == 1) return;
+
+  else if (count == 0) {
+    std::cerr << "No world volume provided. ";
+  }
+
+  else {
+    std::cerr   << "Too many world volumes provided:";
+    for (auto& name : names)
+      std::cerr << "\n ->" << name;
+  }
+
+  std::cerr     << "\nYou must provide exactly one world volume."
+                << std::endl;
+  exit(EXIT_FAILURE);
+}
+
 }

--- a/nain4/n4_run_manager.hh
+++ b/nain4/n4_run_manager.hh
@@ -44,6 +44,8 @@ namespace nain4 {
 // geometry to commute with actions and physics. However our
 // constraint imposes no loss of generality.
 
+void check_for_multiple_world_volumes();
+
 class run_manager {
   using RM = std::unique_ptr<G4RunManager>;
 
@@ -104,7 +106,9 @@ public:
     using gn_type = std::function<n4::generator*()>;
     using ac_type = std::function<n4::actions  *()>;
   private: // To reduce the possibility of instantiating generator before setting physics
-    NEXT_STATE_BASIC(run_manager, actions, G4VUserActionInitialization, manager -> Initialize())
+    NEXT_STATE_BASIC( run_manager, actions, G4VUserActionInitialization
+                    , manager -> Initialize();
+                      check_for_multiple_world_volumes())
   public:
     NEXT_CONSTRUCT  (run_manager, actions)
     NEXT_BUILD_FN   (run_manager, actions, fn_type, new n4::actions{new n4::generator{build}})

--- a/nain4/test/test-run-manager.cc
+++ b/nain4/test/test-run-manager.cc
@@ -118,3 +118,22 @@ TEST_CASE("nain run_manager too_many_world_volumes", "[nain][run_manager]") {
      .actions(do_nothing);
 
 }
+
+
+TEST_CASE("nain run_manager exactly_one_world_volumes", "[nain][run_manager]") {
+  auto my_geometry = [] {
+    auto air = n4::material("G4_AIR");
+    auto box_daughter = n4::box{"daughter"}.cube(1).volume(air);
+    auto box_world    = n4::box{"world"   }.cube(1).volume(air);
+
+    // No `.in` call defaults to world volume
+           n4::place(box_daughter).in(box_world).now();
+    return n4::place(box_world   ).now();
+  };
+
+  n4::run_manager::create()
+     .physics<FTFP_BERT>(0)
+     .geometry(my_geometry)
+     .actions(do_nothing);
+
+}

--- a/nain4/test/test-run-manager.cc
+++ b/nain4/test/test-run-manager.cc
@@ -1,7 +1,9 @@
 #include "nain4.hh"
 #include "test_utils.hh"
+#include "n4-volumes.hh"
 
 // Solids
+#include <FTFP_BERT.hh>
 #include <G4Box.hh>
 #include <G4Cons.hh>
 #include <G4Trd.hh>
@@ -78,4 +80,41 @@ TEST_CASE("nain run_manager get", "[nain][run_manager]") {
   auto& rm_reference = n4::run_manager::get();
 
   CHECK(&rm_value == &rm_reference);
+}
+
+TEST_CASE("nain run_manager no_world_volume", "[nain][run_manager]") {
+  auto my_geometry = [] {
+    auto air = n4::material("G4_AIR");
+    auto box_world    = n4::box{"world"   }.cube(1).volume(air);
+    auto box_daughter = n4::box{"daughter"}.cube(1).volume(air);
+
+    // We place the daughter
+    // But we forget to place the mother
+    // And we should get an error
+    return n4::place(box_daughter).in(box_world).now();
+    //     n4::place(box_mother  ).             .now();
+  };
+
+  n4::run_manager::create()
+     .physics<FTFP_BERT>(0)
+     .geometry(my_geometry)
+     .actions(do_nothing);
+}
+
+TEST_CASE("nain run_manager too_many_world_volumes", "[nain][run_manager]") {
+  auto my_geometry = [] {
+    auto air = n4::material("G4_AIR");
+    auto box_world_1 = n4::box{"world-1"}.cube(1).volume(air);
+    auto box_world_2 = n4::box{"world-2"}.cube(1).volume(air);
+
+    // No `.in` call defaults to world volume
+           n4::place(box_world_1).now();
+    return n4::place(box_world_2).now();
+  };
+
+  n4::run_manager::create()
+     .physics<FTFP_BERT>(0)
+     .geometry(my_geometry)
+     .actions(do_nothing);
+
 }

--- a/nain4/test/test-run-manager.cc
+++ b/nain4/test/test-run-manager.cc
@@ -82,6 +82,9 @@ TEST_CASE("nain run_manager get", "[nain][run_manager]") {
   CHECK(&rm_value == &rm_reference);
 }
 
+// These tests are commented out because we still don't know how to get Catch2
+// to assert failures.
+
 // TEST_CASE("nain run_manager no_world_volume", "[nain][run_manager]") {
 //   auto my_geometry = [] {
 //     auto air = n4::material("G4_AIR");

--- a/nain4/test/test-run-manager.cc
+++ b/nain4/test/test-run-manager.cc
@@ -82,44 +82,44 @@ TEST_CASE("nain run_manager get", "[nain][run_manager]") {
   CHECK(&rm_value == &rm_reference);
 }
 
-TEST_CASE("nain run_manager no_world_volume", "[nain][run_manager]") {
-  auto my_geometry = [] {
-    auto air = n4::material("G4_AIR");
-    auto box_world    = n4::box{"world"   }.cube(1).volume(air);
-    auto box_daughter = n4::box{"daughter"}.cube(1).volume(air);
+// TEST_CASE("nain run_manager no_world_volume", "[nain][run_manager]") {
+//   auto my_geometry = [] {
+//     auto air = n4::material("G4_AIR");
+//     auto box_world    = n4::box{"world"   }.cube(1).volume(air);
+//     auto box_daughter = n4::box{"daughter"}.cube(1).volume(air);
 
-    // We place the daughter
-    // But we forget to place the mother
-    // And we should get an error
-    return n4::place(box_daughter).in(box_world).now();
-    //     n4::place(box_mother  ).             .now();
-  };
+//     // We place the daughter
+//     // But we forget to place the mother
+//     // And we should get an error
+//     return n4::place(box_daughter).in(box_world).now();
+//     //     n4::place(box_mother  ).             .now();
+//   };
 
-  auto hush = n4::silence{std::cout};
-  n4::run_manager::create()
-     .physics<FTFP_BERT>(0)
-     .geometry(my_geometry)
-     .actions(do_nothing);
-}
+//   auto hush = n4::silence{std::cout};
+//   n4::run_manager::create()
+//      .physics<FTFP_BERT>(0)
+//      .geometry(my_geometry)
+//      .actions(do_nothing);
+// }
 
-TEST_CASE("nain run_manager too_many_world_volumes", "[nain][run_manager]") {
-  auto my_geometry = [] {
-    auto air = n4::material("G4_AIR");
-    auto box_world_1 = n4::box{"world-1"}.cube(1).volume(air);
-    auto box_world_2 = n4::box{"world-2"}.cube(1).volume(air);
+// TEST_CASE("nain run_manager too_many_world_volumes", "[nain][run_manager]") {
+//   auto my_geometry = [] {
+//     auto air = n4::material("G4_AIR");
+//     auto box_world_1 = n4::box{"world-1"}.cube(1).volume(air);
+//     auto box_world_2 = n4::box{"world-2"}.cube(1).volume(air);
 
-    // No `.in` call defaults to world volume
-           n4::place(box_world_1).now();
-    return n4::place(box_world_2).now();
-  };
+//     // No `.in` call defaults to world volume
+//            n4::place(box_world_1).now();
+//     return n4::place(box_world_2).now();
+//   };
 
-  auto hush = n4::silence{std::cout};
-  n4::run_manager::create()
-     .physics<FTFP_BERT>(0)
-     .geometry(my_geometry)
-     .actions(do_nothing);
+//   auto hush = n4::silence{std::cout};
+//   n4::run_manager::create()
+//      .physics<FTFP_BERT>(0)
+//      .geometry(my_geometry)
+//      .actions(do_nothing);
 
-}
+// }
 
 
 TEST_CASE("nain run_manager exactly_one_world_volumes", "[nain][run_manager]") {

--- a/nain4/test/test-run-manager.cc
+++ b/nain4/test/test-run-manager.cc
@@ -95,6 +95,7 @@ TEST_CASE("nain run_manager no_world_volume", "[nain][run_manager]") {
     //     n4::place(box_mother  ).             .now();
   };
 
+  auto hush = n4::silence{std::cout};
   n4::run_manager::create()
      .physics<FTFP_BERT>(0)
      .geometry(my_geometry)
@@ -112,6 +113,7 @@ TEST_CASE("nain run_manager too_many_world_volumes", "[nain][run_manager]") {
     return n4::place(box_world_2).now();
   };
 
+  auto hush = n4::silence{std::cout};
   n4::run_manager::create()
      .physics<FTFP_BERT>(0)
      .geometry(my_geometry)
@@ -131,6 +133,7 @@ TEST_CASE("nain run_manager exactly_one_world_volumes", "[nain][run_manager]") {
     return n4::place(box_world   ).now();
   };
 
+  auto hush = n4::silence{std::cout};
   n4::run_manager::create()
      .physics<FTFP_BERT>(0)
      .geometry(my_geometry)


### PR DESCRIPTION
Closes #54 

Adds a check at run manager initialization time for world volume validity. There must be exactly 1 world volume (defined as a physical volume without a mother volume).

Tests fail intentionally for demonstration purposes.