### PR TITLE
More methods and tests for material properties

### DIFF
--- a/examples/00-basic/n4app.cc
+++ b/examples/00-basic/n4app.cc
@@ -94,7 +94,7 @@ int main(int argc, char* argv[]) {
   // Important! physics list has to be set before the generator!
   .physics<FTFP_BERT>(0) // version 0
   .geometry(my_geometry)
-    .actions([&] {return create_actions(n_event); });
+  .actions([&] {return create_actions(n_event); });
   // ANCHOR_END: build_minimal_framework
 
   // ANCHOR: run

--- a/nain4/nain4.cc
+++ b/nain4/nain4.cc
@@ -104,7 +104,7 @@ material_properties& material_properties::copy_from(
   G4MaterialPropertiesTable const * const other,
   std::vector<std::string> const& keys
 ) {
-  for (auto key : keys) { add(key, other -> GetProperty(key)); }
+  for (auto key : keys) { copy_from(other, key); }
   return *this;
 }
 
@@ -112,7 +112,24 @@ material_properties& material_properties::copy_NEW_from(
   G4MaterialPropertiesTable const * const other,
   std::vector<std::string> const& keys
 ) {
-  for (auto key : keys) { NEW(key, other -> GetProperty(key)); }
+  for (auto key : keys) { copy_NEW_from(other, key); }
+  return *this;
+}
+
+
+material_properties& material_properties::copy_from(
+  G4MaterialPropertiesTable const * const other,
+  std::string const& key
+) {
+  add(key, other -> GetProperty(key));
+  return *this;
+}
+
+material_properties& material_properties::copy_NEW_from(
+  G4MaterialPropertiesTable const * const other,
+  std::string const& key
+) {
+  NEW(key, other -> GetProperty(key));
   return *this;
 }
 

--- a/nain4/nain4.cc
+++ b/nain4/nain4.cc
@@ -9,6 +9,7 @@
 #include <G4String.hh>
 
 #include <algorithm>
+#include <initializer_list>
 #include <iterator>
 
 #pragma GCC diagnostic push
@@ -116,12 +117,28 @@ material_properties& material_properties::copy_NEW_from(
   return *this;
 }
 
+material_properties& material_properties::copy_from(
+  G4MaterialPropertiesTable const * const other,
+  std::initializer_list<std::string> const& keys
+) {
+  for (auto key : keys) { copy_from(other, key); }
+  return *this;
+}
+
+material_properties& material_properties::copy_NEW_from(
+  G4MaterialPropertiesTable const * const other,
+  std::initializer_list<std::string> const& keys
+) {
+  for (auto key : keys) { copy_NEW_from(other, key); }
+  return *this;
+}
 
 material_properties& material_properties::copy_from(
   G4MaterialPropertiesTable const * const other,
   std::string const& key
 ) {
-  add(key, other -> GetProperty(key));
+  if (other -> ConstPropertyExists(key)) { add(key, other -> GetConstProperty(key)); }
+  else                                   { add(key, other ->      GetProperty(key)); }
   return *this;
 }
 
@@ -129,7 +146,8 @@ material_properties& material_properties::copy_NEW_from(
   G4MaterialPropertiesTable const * const other,
   std::string const& key
 ) {
-  NEW(key, other -> GetProperty(key));
+  if (other -> ConstPropertyExists(key)) { NEW(key, other -> GetConstProperty(key)); }
+  else                                   { NEW(key, other ->      GetProperty(key)); }
   return *this;
 }
 

--- a/nain4/nain4.hh
+++ b/nain4/nain4.hh
@@ -243,6 +243,8 @@ public:
   material_properties& NEW(G4String const& key, G4MaterialPropertyVector* value);
   material_properties& copy_from    (G4MaterialPropertiesTable const * const other, std::vector<std::string> const& keys);
   material_properties& copy_NEW_from(G4MaterialPropertiesTable const * const other, std::vector<std::string> const& keys);
+  material_properties& copy_from    (G4MaterialPropertiesTable const * const other, std::initializer_list<std::string> const& keys);
+  material_properties& copy_NEW_from(G4MaterialPropertiesTable const * const other, std::initializer_list<std::string> const& keys);
   material_properties& copy_from    (G4MaterialPropertiesTable const * const other,             std::string  const& key );
   material_properties& copy_NEW_from(G4MaterialPropertiesTable const * const other,             std::string  const& key );
   G4MaterialPropertiesTable* done() { return table; }

--- a/nain4/nain4.hh
+++ b/nain4/nain4.hh
@@ -243,6 +243,8 @@ public:
   material_properties& NEW(G4String const& key, G4MaterialPropertyVector* value);
   material_properties& copy_from    (G4MaterialPropertiesTable const * const other, std::vector<std::string> const& keys);
   material_properties& copy_NEW_from(G4MaterialPropertiesTable const * const other, std::vector<std::string> const& keys);
+  material_properties& copy_from    (G4MaterialPropertiesTable const * const other,             std::string  const& key );
+  material_properties& copy_NEW_from(G4MaterialPropertiesTable const * const other,             std::string  const& key );
   G4MaterialPropertiesTable* done() { return table; }
 private:
   G4MaterialPropertiesTable* table = new G4MaterialPropertiesTable;

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -316,7 +316,6 @@ TEST_CASE("nain sphere", "[nain][sphere]") {
   check_phi(phi_e ,     0,   end         );
   check_phi(phi_d ,     0, delta         );
 
-  using CLHEP::pi;
   start = pi/8; end = pi/2; delta = pi/4;
   auto theta_s  = spherer("theta_s" ).theta_start(start) /*.end(180)*/     .solid();
   auto theta_se = spherer("theta_se").theta_start(start).theta_end  (end  ).solid();

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -173,6 +173,197 @@ TEST_CASE("nain material", "[nain][material]") {
   }
 }
 
+TEST_CASE("nain material_properties", "[nain][material_properties]") {
+  SECTION("add") {
+    auto key_1         = "RINDEX";
+    auto key_2         = "ABSLENGTH";
+    auto key_3         = "SCINTILLATIONTIMECONSTANT1";
+
+    auto energies_1    = std::vector<G4double>{1 , 4 , 6};
+    auto energies_2    = std::vector<G4double>{2 ,     7};
+
+    auto   values_1    = std::vector<G4double>{3., 5., 8.};
+    auto const_value_2 = CLHEP::pi;
+    auto const_value_3 = 42.0;
+
+    auto mp = n4::material_properties()
+      .add(key_1, energies_1,      values_1) // vec vec
+      .add(key_2, energies_2, const_value_2) // vec const
+      .add(key_3,             const_value_3) //     const
+      .done();
+
+    auto property_1 = mp -> GetProperty(key_1);
+    for (auto i=0; i<3; i++) {
+      auto e1 = energies_1[i];
+      CHECK( property_1 -> Energy(i)  == e1);
+      CHECK( property_1 -> Value (e1) == values_1[i]);
+    }
+
+    auto property_2 = mp -> GetProperty(key_2);
+    for (auto i=0; i<2; i++){
+      auto e2 = energies_2[i];
+      CHECK( property_2 -> Energy(i)  == e2);
+      CHECK( property_2 -> Value (e2) == const_value_2);
+    }
+
+    CHECK( mp ->    ConstPropertyExists(key_3)                );
+    CHECK( mp -> GetConstProperty      (key_3) == const_value_3 );
+  }
+
+  SECTION("initializer lists") {
+    auto key      = "RINDEX";
+    auto energies = {3., 4., 5.};
+    auto values   = {6., 7., 8.};
+    auto mp       = n4::material_properties() .add(key, energies, values) .done();
+
+    auto property = mp -> GetProperty("RINDEX");
+    for (auto i=0; i<3; i++) {
+      auto e = 3 + i;
+      CHECK( property -> Energy(i) == 3 + i );
+      CHECK( property -> Value (e) == 6 + i );
+    }
+  }
+
+  SECTION("NEW") {
+    auto key_1 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_VEC";
+    auto key_2 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_CONST";
+    auto key_3 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_CONST";
+
+    auto energies_1 = std::vector<G4double>{1., 3., 4.};
+    auto energies_2 = std::vector<G4double>{2.,     5.};
+
+    auto      values_1 = std::vector<G4double>{7., 8., 9.};
+    auto const_value_2 = CLHEP::pi;
+    auto const_value_3 = 42.;
+
+    auto mp = n4::material_properties()
+      .NEW(key_1, energies_1,      values_1)
+      .NEW(key_2, energies_2, const_value_2)
+      .NEW(key_3,             const_value_3)
+      .done();
+
+    auto property_1 = mp -> GetProperty(key_1);
+    for (auto i=0; i<3; i++){
+      auto e1 = energies_1[i];
+      CHECK( property_1 -> Energy(i)  == e1);
+      CHECK( property_1 -> Value (e1) == values_1[i]);
+    }
+
+    auto property_2 = mp -> GetProperty(key_2);
+    for (auto i=0; i<2; i++){
+      auto e2 = energies_2[i];
+      CHECK( property_2 -> Energy(i)  == e2);
+      CHECK( property_2 -> Value (e2) == const_value_2);
+    }
+
+    CHECK( mp ->    ConstPropertyExists(key_3)                  );
+    CHECK( mp -> GetConstProperty      (key_3) == const_value_3 );
+  }
+
+
+  SECTION("copy another mpt's values by hand") {
+    auto key_1 = "RINDEX";
+    auto key_2 = "ABSLENGTH";
+    auto key_3 = "SCINTILLATIONTIMECONSTANT1";
+    auto key_4 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_VEC";
+    auto key_5 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_CONST";
+    auto key_6 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_CONST";
+
+    auto energies_1 = std::vector<G4double>{1., 5.,  7.};
+    auto energies_2 = std::vector<G4double>{2.,      8.};
+    auto energies_4 = std::vector<G4double>{3., 6.,  9.};
+    auto energies_5 = std::vector<G4double>{4.,     10.};
+
+    auto      values_1 = std::vector<G4double>{11., 12., 13.};
+    auto const_value_2 = CLHEP::pi;
+    auto const_value_3 = 42.;
+    auto      values_4 = std::vector<G4double>{14., 15., 16.};
+    auto const_value_5 = CLHEP::twopi;
+    auto const_value_6 = 42. * 42.;
+
+    auto mp1 = n4::material_properties()
+      .add(key_1, energies_1,      values_1)
+      .add(key_2, energies_2, const_value_2)
+      .add(key_3,             const_value_3)
+      .NEW(key_4, energies_4,      values_4)
+      .NEW(key_5, energies_5, const_value_5)
+      .NEW(key_6,             const_value_6)
+      .done();
+
+    auto mp2 = n4::material_properties()
+      .add(key_1, mp1 -> GetProperty(key_1))
+      .add(key_2, mp1 -> GetProperty(key_2))
+      .add(key_3, mp1 -> GetConstProperty(key_3)) // Must use Const!!!!
+      .NEW(key_4, mp1 -> GetProperty(key_4))
+      .NEW(key_5, mp1 -> GetProperty(key_5))
+      .NEW(key_6, mp1 -> GetProperty(key_6))
+      .done();
+
+    CHECK( mp2 -> GetProperty(key_1)  ==  mp1 -> GetProperty(key_1) );
+    CHECK( mp2 -> GetProperty(key_2)  ==  mp1 -> GetProperty(key_2) );
+    CHECK( mp2 -> GetProperty(key_3)  ==  mp1 -> GetProperty(key_3) );
+    CHECK( mp2 -> GetProperty(key_4)  ==  mp1 -> GetProperty(key_4) );
+    CHECK( mp2 -> GetProperty(key_5)  ==  mp1 -> GetProperty(key_5) );
+    CHECK( mp2 -> GetProperty(key_6)  ==  mp1 -> GetProperty(key_6) );
+  }
+
+  SECTION("copy another mpt's values by key") {
+    auto key_1 = "RINDEX";
+    auto key_2 = "ABSLENGTH";
+    auto key_3 = "SCINTILLATIONTIMECONSTANT1";
+    auto key_4 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_VEC";
+    auto key_5 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_VEC_CONST";
+    auto key_6 = "SOMETHING_THAT_DID_NOT_EXIST_BEFORE_CONST";
+
+    auto energies_1 = std::vector<G4double>{1., 5.,  7.};
+    auto energies_2 = std::vector<G4double>{2.,      8.};
+    auto energies_4 = std::vector<G4double>{3., 6.,  9.};
+    auto energies_5 = std::vector<G4double>{4.,     10.};
+
+    auto      values_1 = std::vector<G4double>{11., 12., 13.};
+    auto const_value_2 = CLHEP::pi;
+    auto const_value_3 = 42.;
+    auto      values_4 = std::vector<G4double>{14., 15., 16.};
+    auto const_value_5 = CLHEP::twopi;
+    auto const_value_6 = 42. * 42.;
+
+    auto mp1 = n4::material_properties()
+      .add(key_1, energies_1,      values_1)
+      .add(key_2, energies_2, const_value_2)
+      .add(key_3,             const_value_3)
+      .NEW(key_4, energies_4,      values_4)
+      .NEW(key_5, energies_5, const_value_5)
+      .NEW(key_6,             const_value_6)
+      .done();
+
+    auto mp2 = n4::material_properties()
+      .copy_from    (mp1,  key_1        ) // single key
+      .copy_from    (mp1, {key_2, key_3}) // multiple keys
+      .copy_NEW_from(mp1,  key_4        ) // single key
+      .copy_NEW_from(mp1, {key_5, key_6}) // multiple keys
+      .done();
+
+    CHECK( mp2 -> GetProperty(key_1)  ==  mp1 -> GetProperty(key_1) );
+    CHECK( mp2 -> GetProperty(key_2)  ==  mp1 -> GetProperty(key_2) );
+    CHECK( mp2 -> GetProperty(key_3)  ==  mp1 -> GetProperty(key_3) );
+    CHECK( mp2 -> GetProperty(key_4)  ==  mp1 -> GetProperty(key_4) );
+    CHECK( mp2 -> GetProperty(key_5)  ==  mp1 -> GetProperty(key_5) );
+    CHECK( mp2 -> GetProperty(key_6)  ==  mp1 -> GetProperty(key_6) );
+  }
+}
+
+
+
+//     .add("RINDEX",      ri_energy,       rIndex)                                                              |5d696f3 * Nanify some G4Tubs                                                                              Jacek Generowicz   12 hours
+// .add("ABSLENGTH"                 , optPhotRangeE_, noAbsLength_)                                                              |2811bdd * Remove pointless dots and braces                                                                Jacek Generowicz   12 hours
+// .add("SCINTILLATIONCOMPONENT1"   , sc_energy_Ar  , intensity_Ar)                                                              |0ee9072 * Remove pointless underscores                                                                    Jacek Generowicz   12 hours
+// .add("SCINTILLATIONCOMPONENT2"   , sc_energy_Ar  , intensity_Ar)                                                              |13f9305 * Explore easier visualization of sub-geometry                                                    Jacek Generowicz   16 hours
+// .NEW("ELSPECTRUM"                , sc_energy_Ar  , intensity_Ar)                                                              |fd03e01 * Extract parameter initialization from geometry()                                                Jacek Generowicz   16 hours
+// .add("SCINTILLATIONYIELD"        ,                   sc_yield  )                                                              |398bb20 * Better visualization                                                                            Gonzalo Martinez …  1 day
+// .add("SCINTILLATIONTIMECONSTANT1",                      6. * ns) //
+
+
+
 TEST_CASE("nain shape name", "[nain][shape][name]") {
   auto name1  = "fulanito";
   auto name2  = "menganito";

--- a/nain4/test/test-nain4.cc
+++ b/nain4/test/test-nain4.cc
@@ -352,18 +352,6 @@ TEST_CASE("nain material_properties", "[nain][material_properties]") {
   }
 }
 
-
-
-//     .add("RINDEX",      ri_energy,       rIndex)                                                              |5d696f3 * Nanify some G4Tubs                                                                              Jacek Generowicz   12 hours
-// .add("ABSLENGTH"                 , optPhotRangeE_, noAbsLength_)                                                              |2811bdd * Remove pointless dots and braces                                                                Jacek Generowicz   12 hours
-// .add("SCINTILLATIONCOMPONENT1"   , sc_energy_Ar  , intensity_Ar)                                                              |0ee9072 * Remove pointless underscores                                                                    Jacek Generowicz   12 hours
-// .add("SCINTILLATIONCOMPONENT2"   , sc_energy_Ar  , intensity_Ar)                                                              |13f9305 * Explore easier visualization of sub-geometry                                                    Jacek Generowicz   16 hours
-// .NEW("ELSPECTRUM"                , sc_energy_Ar  , intensity_Ar)                                                              |fd03e01 * Extract parameter initialization from geometry()                                                Jacek Generowicz   16 hours
-// .add("SCINTILLATIONYIELD"        ,                   sc_yield  )                                                              |398bb20 * Better visualization                                                                            Gonzalo Martinez …  1 day
-// .add("SCINTILLATIONTIMECONSTANT1",                      6. * ns) //
-
-
-
 TEST_CASE("nain shape name", "[nain][shape][name]") {
   auto name1  = "fulanito";
   auto name2  = "menganito";
@@ -373,7 +361,6 @@ TEST_CASE("nain shape name", "[nain][shape][name]") {
 
   CHECK( solid1 -> GetName() == name1 );
   CHECK( solid2 -> GetName() == name2 );
-
 }
 
 TEST_CASE("nain box", "[nain][box]") {


### PR DESCRIPTION
I've added more methods for material properties. Namely, those that:
- Take a single key to copy from another table: This applies to both methods: `add` and `NEW`
- Take an initializer list (necessary to resolve the ambiguity between the constructors of `std::vector<std::string>` and `std::string`).

But the main reason for this PR is to add tests to `n4::material_properties`. I've added a single test with many sections. Please let me know what you think.