### PR TITLE
Find tag automatically in client-side test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,14 @@ jobs:
           # If you chose API tokens for write access OR if you have a private cache
           authToken: '${{ secrets.CACHIX_JACG_NAIN4 }}'
 
+      - name: pre-build
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "GITHUB_USERNAME=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
+          else
+            echo "GITHUB_USERNAME=${{ github.actor }}" >> $GITHUB_ENV
+          fi
+
       - name: Nix build
         run: nix develop
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-23.05

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ compile_commands.json
 .README.txt
 G4History.macro
 /install/
+**/.gdb_history
+**/Testing
+
+/g4-examples/*
+!/g4-examples/justfile

--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -2,10 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(Client)
 
-execute_process(
-  COMMAND bash -c "git config --get remote.origin.url | cut -d '/' -f 4 | tr -d '\n'"
-  OUTPUT_VARIABLE USERNAME
-)
+set(USERNAME $ENV{GITHUB_USERNAME})
 
 execute_process(
   COMMAND bash -c "git log -1 | head -1 | cut -d ' ' -f 2 | tr -d '\n'"

--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.25)
 project(Client)
 
 execute_process(
-  COMMAND bash -c "git tag | tail -1 | tr -d '\n'"
-  OUTPUT_VARIABLE TAG
+  COMMAND bash -c "git config --get remote.origin.url | cut -d '/' -f 4 | tr -d '\n'"
+  OUTPUT_VARIABLE USERNAME
 )
 
-message("Using Nain4 tag: ${TAG}")
+execute_process(
+  COMMAND bash -c "git log -1 | head -1 | cut -d ' ' -f 2 | tr -d '\n'"
+  OUTPUT_VARIABLE COMMIT_HASH
+)
+
+message("Using username: <${USERNAME}>")
+message("Using commit: <${COMMIT_HASH}>")
 
 # ANCHOR: fetch
 include(FetchContent)
@@ -16,8 +22,8 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Cache package contents to a
 
 FetchContent_Declare(
   Nain4
-  GIT_REPOSITORY https://github.com/jacg/nain4.git
-  GIT_TAG        ${TAG}
+  GIT_REPOSITORY https://github.com/${USERNAME}/nain4.git
+  GIT_TAG        ${COMMIT_HASH}
   # make sure that no other nain4 installation is used
   OVERRIDE_FIND_PACKAGE
   SOURCE_SUBDIR nain4

--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.25)
 
 project(Client)
 
+execute_process(
+  COMMAND bash -c "git tag | tail -1 | tr -d '\n'"
+  OUTPUT_VARIABLE TAG
+)
+
+message("Using Nain4 tag: ${TAG}")
+
 # ANCHOR: fetch
 include(FetchContent)
 
@@ -10,7 +17,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Cache package contents to a
 FetchContent_Declare(
   Nain4
   GIT_REPOSITORY https://github.com/jacg/nain4.git
-  GIT_TAG        v0.1.9
+  GIT_TAG        ${TAG}
   # make sure that no other nain4 installation is used
   OVERRIDE_FIND_PACKAGE
   SOURCE_SUBDIR nain4

--- a/client_side_tests/test_fetch_content.sh
+++ b/client_side_tests/test_fetch_content.sh
@@ -3,7 +3,6 @@
 test_dir=$(dirname "$(readlink -f "$0")")
 tmp_dir=$(mktemp -d -t nain4-fetch-content-XXXXXX)
 
-cd $tmp_dir
-cmake -S $test_dir/client_fetch_content -B build && cmake --build build && ./build/client_exe
+cmake -S $test_dir/client_fetch_content -B $tmp_dir/build && cmake --build $tmp_dir/build && $tmp_dir/build/client_exe
 
 exit $?

--- a/client_side_tests/test_fetch_content_recompile.sh
+++ b/client_side_tests/test_fetch_content_recompile.sh
@@ -3,17 +3,16 @@
 tmp_dir=$(mktemp -d -t nain4-recompile-XXXXXX)
 test_dir=$(dirname "$(readlink -f "$0")")
 
-cd $tmp_dir
-cmake -S $test_dir/client_fetch_content -B build
-cmake --build build
-rm -f build/client_exe # Make sure the executable does not exist unless we recompile
+cmake -S $test_dir/client_fetch_content -B $tmp_dir/build
+cmake --build $tmp_dir/build
+rm -f $tmp_dir/build/client_exe # Make sure the executable does not exist unless we recompile
 
 # Block network access temporarily
 sudo iptables -A OUTPUT -j DROP
 
-cmake -S $test_dir/client_fetch_content -B build; status1=$?
-cmake --build build; status2=$?
-./build/client_exe; status3=$?
+cmake -S $test_dir/client_fetch_content -B $tmp_dir/build; status1=$?
+cmake --build $tmp_dir/build; status2=$?
+$tmp_dir/build/client_exe; status3=$?
 
 # Restore network access
 sudo iptables -D OUTPUT -j DROP


### PR DESCRIPTION
This avoids the recurring `Bump tag to vX.Y.Z` commit