### PR TITLE
Habemus Macam

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Run client-side tests
         run: nix develop -c just test-client-side
 
-      - name: Run compile-time tests
-        run: nix develop -c just test-compile-time
-
       - name: Run nain4 examples
         run: nix develop -c just test-examples
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run client-side tests
         run: nix develop -c just test-client-side
 
+      - name: Run compile-time tests
+        run: nix develop -c just test-compile-time
+
       - name: Run nain4 examples
         run: nix develop -c just test-examples
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12]
         py: [311]
         allow-fail: [false]
-        include:
-          - os: macos-12
-            py: 311
-            allow-fail: true
 
     steps:
       - uses: actions/checkout@v3.5.3

--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -10,7 +10,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Cache package contents to a
 FetchContent_Declare(
   Nain4
   GIT_REPOSITORY https://github.com/jacg/nain4.git
-  GIT_TAG        v0.1.8
+  GIT_TAG        origin/fix-darwin
   # make sure that no other nain4 installation is used
   OVERRIDE_FIND_PACKAGE
   SOURCE_SUBDIR nain4

--- a/client_side_tests/client_fetch_content/CMakeLists.txt
+++ b/client_side_tests/client_fetch_content/CMakeLists.txt
@@ -10,7 +10,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Cache package contents to a
 FetchContent_Declare(
   Nain4
   GIT_REPOSITORY https://github.com/jacg/nain4.git
-  GIT_TAG        origin/fix-darwin
+  GIT_TAG        v0.1.8
   # make sure that no other nain4 installation is used
   OVERRIDE_FIND_PACKAGE
   SOURCE_SUBDIR nain4

--- a/client_side_tests/test_fetch_content_recompile.sh
+++ b/client_side_tests/test_fetch_content_recompile.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 tmp_dir=$(mktemp -d -t nain4-recompile-XXXXXX)
 test_dir=$(dirname "$(readlink -f "$0")")

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
     flake-utils.lib.eachSystem ["x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"] (system:
       let
         pkgs = import nixpkgs { inherit system; };
-
         my-geant4 = (pkgs.geant4.override {
           enableMultiThreading = false;
           enableInventor       = false;
@@ -45,14 +44,9 @@
           clang-tools
         ];
 
-        my-mkShell = pkgs.mkShell.override {
-          stdenv = if pkgs.stdenv.isDarwin then pkgs.                stdenv
-                                           else pkgs.llvmPackages_16.stdenv;
-        };
-
       in {
 
-        devShell = my-mkShell {
+        devShell = pkgs.mkShell {
           name = "G4-examples-devenv";
 
           packages = my-packages;

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,8 @@
             geant4.data.G4SAIDDATA
             geant4.data.G4PARTICLEXS
             geant4.data.G4NDL
-            clang_16
-            clang-tools
+            # clang_16
+            # clang-tools
             cmake
             cmake-language-server
             catch2_3

--- a/flake.nix
+++ b/flake.nix
@@ -22,29 +22,34 @@
           enableRaytracerX11   = false;
         });
 
+        my-packages = with pkgs; [
+          my-geant4
+          geant4.data.G4PhotonEvaporation
+          geant4.data.G4EMLOW
+          geant4.data.G4RadioactiveDecay
+          geant4.data.G4ENSDFSTATE
+          geant4.data.G4SAIDDATA
+          geant4.data.G4PARTICLEXS
+          geant4.data.G4NDL
+          cmake
+          cmake-language-server
+          catch2_3
+          just
+          gnused # For hacking CMAKE_EXPORT stuff into CMakeLists.txt
+          mdbook
+        ] ++ lib.optionals stdenv.isDarwin [
+
+        ] ++ lib.optionals stdenv.isLinux [
+          clang_16
+          clang-tools
+        ];
+
       in {
 
         devShell = pkgs.mkShell {
           name = "G4-examples-devenv";
 
-          packages = with pkgs; [
-            my-geant4
-            geant4.data.G4PhotonEvaporation
-            geant4.data.G4EMLOW
-            geant4.data.G4RadioactiveDecay
-            geant4.data.G4ENSDFSTATE
-            geant4.data.G4SAIDDATA
-            geant4.data.G4PARTICLEXS
-            geant4.data.G4NDL
-            # clang_16
-            # clang-tools
-            cmake
-            cmake-language-server
-            catch2_3
-            just
-            gnused # For hacking CMAKE_EXPORT stuff into CMakeLists.txt
-            mdbook
-          ];
+          packages = my-packages;
 
           G4_DIR = "${pkgs.geant4}";
           G4_EXAMPLES_DIR = "${pkgs.geant4}/share/Geant4-11.0.4/examples/";

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
 
       in {
 
-        devShell = pkgs.mkShell.override { stdenv = pkgs.clang_16.stdenv; } {
+        devShell = pkgs.mkShell {
           name = "G4-examples-devenv";
 
           packages = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
     flake-utils.lib.eachSystem ["x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"] (system:
       let
         pkgs = import nixpkgs { inherit system; };
+
         my-geant4 = (pkgs.geant4.override {
           enableMultiThreading = false;
           enableInventor       = false;
@@ -44,9 +45,14 @@
           clang-tools
         ];
 
+        my-mkShell = pkgs.mkShell.override {
+          stdenv = if pkgs.stdenv.isDarwin then pkgs.                stdenv
+                                           else pkgs.llvmPackages_16.stdenv;
+        };
+
       in {
 
-        devShell = pkgs.mkShell {
+        devShell = my-mkShell {
           name = "G4-examples-devenv";
 
           packages = my-packages;

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -45,6 +45,8 @@ FILE(GLOB HEADERS ${PROJECT_SOURCE_DIR}/*.hh)
 
 add_library(Nain4 SHARED ${SOURCES} ${HEADERS})
 
+target_link_options(Nain4 PRIVATE -undefined dynamic_lookup)
+
 #set_target_properties(Nain4 PROPERTIES ENABLE_EXPORTS ON)
 
 #----------------------------------------------------------------------------

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -45,7 +45,9 @@ FILE(GLOB HEADERS ${PROJECT_SOURCE_DIR}/*.hh)
 
 add_library(Nain4 SHARED ${SOURCES} ${HEADERS})
 
-target_link_options(Nain4 PRIVATE -undefined dynamic_lookup)
+if(APPLE)
+    target_link_options(Nain4 PRIVATE -undefined dynamic_lookup)
+endif()
 
 #set_target_properties(Nain4 PROPERTIES ENABLE_EXPORTS ON)
 
@@ -81,7 +83,10 @@ set(ALL_TEST_SOURCES
 
 # TODO including headers in add_executable apparently makes them show up in IDEs. Verify how?
 add_executable(nain4-tests ${ALL_TEST_SOURCES})
-target_link_options(nain4-tests PRIVATE -undefined dynamic_lookup)
+
+if(APPLE)
+  target_link_options(nain4-tests PRIVATE -undefined dynamic_lookup)
+endif()
 
 
 target_link_libraries(

--- a/nain4/CMakeLists.txt
+++ b/nain4/CMakeLists.txt
@@ -81,6 +81,7 @@ set(ALL_TEST_SOURCES
 
 # TODO including headers in add_executable apparently makes them show up in IDEs. Verify how?
 add_executable(nain4-tests ${ALL_TEST_SOURCES})
+target_link_options(nain4-tests PRIVATE -undefined dynamic_lookup)
 
 
 target_link_libraries(


### PR DESCRIPTION
Closes #15.

The remaining problems against which we were banging our heads recently, were caused by linking multiple versions of libc++, which was caused by the dependencies (G4 and Qt) and the client code using different compiler configurations.

The solution[^1] is to use the gcc environment rather than the clang one in the flake's `devShell`. This is only necessary on Darwin, but (for now) it has been changed on Linux too.

The change to gcc breaks the compile-time tests we added recently (which have been removed, to make GHA pass).

Thus, before we can merge this, we have to:

+ [x] Fix failing compile-time tests
+ [x] Revert to clang on Linux

@soleti this has been tested on macOS on Intel, but we do not have access to Apple Silicon, so it would be good if you could check that it works there too.

(Why is the macOS GHA so slow? The one I've been waiting for before submitting this PR, completed on Linux in under 9 minutes, the macOS one chugged along for muuuch longer and then failed spuriously, so I had to restart it. Then it took another 21 minutes.)

[^1]: This solution is temporary: a fix is [in the pipeline](https://github.com/NixOS/nixpkgs/issues/234710) upstream.