### PR TITLE
Gcc devshell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,15 @@ jobs:
         )
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-fail }}
+    #continue-on-error: ${{ matrix.allow-fail }}
+    continue-on-error: ${{ matrix.devshell == 'gcc' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-12]
         py: [311]
         devshell: [ clang, gcc ]
-        allow-fail: [false]
+        #allow-fail: [false]
 
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,19 +47,19 @@ jobs:
         run: nix develop
 
       - name: Test nain4
-        run: nix develop ${{ matrix.devshell }} -c just test-nain4
+        run: nix develop .#${{ matrix.devshell }} -c just test-nain4
 
       - name: nix-shell
         run: nix-shell --run just
 
       - name: Run client-side tests
-        run: nix develop ${{ matrix.devshell }}  -c just test-client-side
+        run: nix develop .#${{ matrix.devshell }}  -c just test-client-side
 
       - name: Run compile-time tests
-        run: nix develop ${{ matrix.devshell }}  -c just test-compile-time
+        run: nix develop .#${{ matrix.devshell }}  -c just test-compile-time
 
       - name: Run nain4 examples
-        run: nix develop ${{ matrix.devshell }}  -c just test-examples
+        run: nix develop .#${{ matrix.devshell }}  -c just test-examples
 
       - name: Run G4 examples
-        run: nix develop ${{ matrix.devshell }}  -c just g4-examples/run-examples-that-work
+        run: nix develop .#${{ matrix.devshell }}  -c just g4-examples/run-examples-that-work

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12]
         py: [311]
+        devshell: [ clang, gcc ]
         allow-fail: [false]
 
     steps:
@@ -46,19 +47,19 @@ jobs:
         run: nix develop
 
       - name: Test nain4
-        run: nix develop -c just test-nain4
+        run: nix develop ${{ matrix.devshell }} -c just test-nain4
 
       - name: nix-shell
         run: nix-shell --run just
 
       - name: Run client-side tests
-        run: nix develop -c just test-client-side
+        run: nix develop ${{ matrix.devshell }}  -c just test-client-side
 
       - name: Run compile-time tests
-        run: nix develop -c just test-compile-time
+        run: nix develop ${{ matrix.devshell }}  -c just test-compile-time
 
       - name: Run nain4 examples
-        run: nix develop -c just test-examples
+        run: nix develop ${{ matrix.devshell }}  -c just test-examples
 
       - name: Run G4 examples
-        run: nix develop -c just g4-examples/run-examples-that-work
+        run: nix develop ${{ matrix.devshell }}  -c just g4-examples/run-examples-that-work

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: nix-shell
         run: nix-shell --run just
+        if: ${{ matrix.devshell == 'clang' }}
 
       - name: Run client-side tests
         run: nix develop .#${{ matrix.devshell }}  -c just test-client-side

--- a/flake.nix
+++ b/flake.nix
@@ -59,9 +59,9 @@
         ] ++ lib.optionals stdenv.isLinux [
         ];
 
-      in {
+      in rec {
 
-        devShell = pkgs.mkShell.override { stdenv = pkgs.clang_16.stdenv; } {
+        devShells.clang = pkgs.mkShell.override { stdenv = pkgs.clang_16.stdenv; } {
           name = "nain4-clang-devenv";
 
           packages = my-packages ++ [ clang_16 pkgs.clang-tools ];
@@ -82,6 +82,8 @@
           QT_QPA_PLATFORM_PLUGIN_PATH="${pkgs.libsForQt5.qt5.qtbase.bin}/lib/qt-${pkgs.libsForQt5.qt5.qtbase.version}/plugins";
 
         };
+
+        devShell = devShells.clang;
 
         packages.geant4  = my-geant4;
         packages.default = my-geant4;

--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,6 @@
           geant4.data.G4SAIDDATA
           geant4.data.G4PARTICLEXS
           geant4.data.G4NDL
-          clang_16
-          clang-tools
           cmake
           cmake-language-server
           catch2_3
@@ -64,7 +62,18 @@
       in {
 
         devShell = pkgs.mkShell.override { stdenv = pkgs.clang_16.stdenv; } {
-          name = "G4-examples-devenv";
+          name = "nain4-clang-devenv";
+
+          packages = my-packages ++ [ clang_16 pkgs.clang-tools ];
+
+          G4_DIR = "${pkgs.geant4}";
+          G4_EXAMPLES_DIR = "${pkgs.geant4}/share/Geant4-11.0.4/examples/";
+          QT_QPA_PLATFORM_PLUGIN_PATH="${pkgs.libsForQt5.qt5.qtbase.bin}/lib/qt-${pkgs.libsForQt5.qt5.qtbase.version}/plugins";
+
+        };
+
+        devShells.gcc = pkgs.mkShell {
+          name = "nain4-gcc-devenv";
 
           packages = my-packages;
 


### PR DESCRIPTION
Adds a second devShell which uses gcc instead of clang. This means we can now do

1. `nix develop <path-to-flake>` 
2. `nix develop <path-to-flake>#gcc`
3. `nix develop <path-to-flake>#clang`

1&3 give a clang environment, 2 gives a gcc environment.

This could be useful for users who have a strong preference, but, above all, for allowing us to test both gcc and clang on GHA.

However, I'm unsure about how we should organize the workflows? Specifically, should the gcc and clang tests be run in

1.  the same job
2. two separate jobs

?

+ Pro 1
   - trivial to set up
   - uses less CPU and network (doesn't need to boostrap the GHA environment twice)
+ Pro 2
   - reports gcc failures separately from clang failures
   - runs in parallel, so completes more quickly

Note: this sits on top of the as-yet-unmerged #82.

Closes #17.