### PR TITLE
Prettify tests output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         run: nix develop
 
       - name: Test nain4
-        run: nix develop .#${{ matrix.devshell }} -c just test-nain4
+        run: nix develop .#${{ matrix.devshell }} -c just test-nain4 -v
 
       - name: Test bootstrapping of client project
         run: |

--- a/justfile
+++ b/justfile
@@ -1,12 +1,13 @@
 # -*-Makefile-*-
 
+_ *FLAGS_AND_ARGS:
+    just test-nain4 {{FLAGS_AND_ARGS}}
+
 test-nain4 *FLAGS:
     just nain4/test-all {{FLAGS}}
 
-
 test-examples:
     just examples/
-
 
 test-client-side:
     just client_side_tests/test-all

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # -*-Makefile-*-
 
-test-nain4:
-    just nain4/test-all
+test-nain4 *FLAGS:
+    just nain4/test-all {{FLAGS}}
 
 
 test-examples:

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -15,7 +15,9 @@ EXE=@CMAKE_INSTALL_PREFIX@/bin/@TEST_EXECUTABLE@
 
 while read -r testname
 do
-    if ! $EXE "$testname" ${FLAGS}; then
+    OUTPUT=$($EXE "$testname" ${FLAGS})
+    STATUS=$?
+    if ! $STATUS; then
         FAILED=$FAILED"$testname"\\n
         NFAILED=$((NFAILED+1))
     else

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -1,23 +1,22 @@
 #!/usr/bin/env sh
 
-if $1 -eq "-v"; then
-    verbose=true
-    shift
-else
-    verbose=false
-fi
 
+case $1 in
+    -vv) PATTERN=""; verbose=2; shift; FLAGS=$@ ;;
+    -v ) PATTERN=""; verbose=1; shift; FLAGS=$@ ;;
+    *  ) PATTERN=$1; case $2 in
+                         -vv) verbose=2; shift; shift; FLAGS=$@ ;;
+                         -v ) verbose=1; shift; shift; FLAGS=$@ ;;
+                         *  ) verbose=0;               FLAGS=$@ ;;
+                     esac ;;
+esac
 
-PATTERN=$1
-if [ ! -z $2 ]; then
-    shift
-    shift
-fi
-FLAGS=$@
 
 NPASSED=0
 NFAILED=0
 FAILED=
+
+echo VERBOSE $verbose
 
 EXE=@CMAKE_INSTALL_PREFIX@/bin/@TEST_EXECUTABLE@
 
@@ -26,15 +25,19 @@ do
     OUTPUT=$($EXE "$testname" ${FLAGS})
     STATUS=$?
     if [ $STATUS -ne 0 ]; then
-        if $verbose; then printf "\\033[91m    %s\n" "${testname}";
-        else              printf "\\033[91mF";
-        fi
+        case $verbose in
+            2) printf "\\033[91m%s\n\n" "$OUTPUT" ;;
+            1) printf "\\033[91m    %s\n" "${testname}" ;;
+            0) printf "\\033[91mF" ;;
+        esac
         FAILED=$FAILED"$testname"\\n
         NFAILED=$((NFAILED+1))
     else
-        if $verbose; then printf "\\033[32m    %s\n" "${testname}";
-        else              printf "\\033[32m.";
-        fi
+        case $verbose in
+            2) printf "\\033[32m%s\n\n" "$OUTPUT" ;;
+            1) printf "\\033[32m    %s\n" "${testname}" ;;
+            0) printf "\\033[32m." ;;
+        esac
         NPASSED=$((NPASSED+1))
     fi
 done < <($EXE ${PATTERN} --list-tests --verbosity quiet)

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
 
+if $1 -eq "-v"; then
+    verbose=true
+    shift
+else
+    verbose=false
+fi
+
+
 PATTERN=$1
 if [ ! -z $2 ]; then
     shift
@@ -17,13 +25,21 @@ while read -r testname
 do
     OUTPUT=$($EXE "$testname" ${FLAGS})
     STATUS=$?
-    if ! $STATUS; then
+    if [ $STATUS -ne 0 ]; then
+        if $verbose; then printf "\\033[91m    %s\n" "${testname}";
+        else              printf "\\033[91mF";
+        fi
         FAILED=$FAILED"$testname"\\n
         NFAILED=$((NFAILED+1))
     else
+        if $verbose; then printf "\\033[32m    %s\n" "${testname}";
+        else              printf "\\033[32m.";
+        fi
         NPASSED=$((NPASSED+1))
     fi
 done < <($EXE ${PATTERN} --list-tests --verbosity quiet)
+echo
+echo
 if ! [ -z "$FAILED" ]; then
     printf "\\033[91m===========================================================================\n"
     printf "\\033[32m Passed $NPASSED tests, \\033[91m Failed $NFAILED\n\n"

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 
-
 case $1 in
     -vv) PATTERN=""; verbose=2; shift; FLAGS=$@ ;;
     -v ) PATTERN=""; verbose=1; shift; FLAGS=$@ ;;
@@ -16,8 +15,6 @@ NPASSED=0
 NFAILED=0
 FAILED=
 
-echo VERBOSE $verbose
-
 EXE=@CMAKE_INSTALL_PREFIX@/bin/@TEST_EXECUTABLE@
 
 while read -r testname
@@ -30,7 +27,10 @@ do
             1) printf "\\033[91m    %s\n" "${testname}" ;;
             0) printf "\\033[91mF" ;;
         esac
-        FAILED=$FAILED"$testname"\\n
+        FAILED=$FAILED"####################################################\n"
+        FAILED=$FAILED"# $testname\n"
+        FAILED=$FAILED"####################################################\n"
+        FAILED=$FAILED"\n${OUTPUT}\n\n\n\n"
         NFAILED=$((NFAILED+1))
     else
         case $verbose in
@@ -43,6 +43,8 @@ do
 done < <($EXE ${PATTERN} --list-tests --verbosity quiet)
 echo
 echo
+
+
 if ! [ -z "$FAILED" ]; then
     printf "\\033[91m===========================================================================\n"
     printf "\\033[32m Passed $NPASSED tests, \\033[91m Failed $NFAILED\n\n"

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -20,7 +20,14 @@ EXE=@CMAKE_INSTALL_PREFIX@/bin/@TEST_EXECUTABLE@
 while read -r testname
 do
     OUTPUT=$($EXE "$testname" ${FLAGS} 2>&1)
+    OUTPUT=${OUTPUT//===============================================================================/}
     STATUS=$?
+
+    if [ $verbose -eq 2 ]; then
+        printf "===============================================================================\n"
+    fi
+
+
     if [ $STATUS -ne 0 ]; then
         case $verbose in
             2) printf "\\033[91m%s\n\n" "$OUTPUT" ;;

--- a/nain4/test/run-each-test-in-separate-process.sh.in
+++ b/nain4/test/run-each-test-in-separate-process.sh.in
@@ -19,7 +19,7 @@ EXE=@CMAKE_INSTALL_PREFIX@/bin/@TEST_EXECUTABLE@
 
 while read -r testname
 do
-    OUTPUT=$($EXE "$testname" ${FLAGS})
+    OUTPUT=$($EXE "$testname" ${FLAGS} 2>&1)
     STATUS=$?
     if [ $STATUS -ne 0 ]; then
         case $verbose in


### PR DESCRIPTION
Implements a pytest-like test output with three different levels of verbosity:
+ `-vv`: full output, similar to what we have now:
```
Filters: "nain material"
Randomness seeded to: 2507992811
===============================================================================
All tests passed (47 assertions in 1 test case)

[...]
```

+ `-v`: just the name of each test
```
    nain material
    nain material_properties
    [...]
```

+ no flags: `.` for success, `F` for failure
```
..........F........F.................

```

The green/red coloring is preserved in all three cases, and they still show the (colored) summary message at the end:
```
Ran 37 tests

===========================================================================
OVERALL: ============================== PASS ==============================
===========================================================================
```

Furthermore, the output of failed tests is shown just before the summary, for instance:
```
####################################################
# nain map
####################################################

Filters: "nain map"
Randomness seeded to: 523894240

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nain4-tests is a Catch2 v3.3.2 host application.
Run with -? for options

-------------------------------------------------------------------------------
nain map
-------------------------------------------------------------------------------
/home/gonzalo/sw/git/nain4/nain4/test/test-nain4.cc:1650
...............................................................................

/home/gonzalo/sw/git/nain4/nain4/test/test-nain4.cc:1660: FAILED:
  CHECK( false )

===============================================================================
test cases: 1 | 1 failed
assertions: 3 | 2 passed | 1 failed
```

Unfortunately, I haven't found a way of passing flags when using the implicit default recipe (e.g.  `just -vv`), so running `just` will run the default behavior which is no flags. To apply the flags we need to do `just test-nain4 [FLAGS]`, which is a bit inconvenient.

