### PR TITLE
Add nix-gl-host

### DIFF
--- a/templates/basic/flake.nix
+++ b/templates/basic/flake.nix
@@ -2,9 +2,10 @@
   description = "CHANGEME-ONE-LINE-PROJECT-DESCRIPTION";
 
   inputs = {
-    nain4  .url     = "github:jacg/nain4";
-    nosys  .follows = "nain4/nosys";
-    nixpkgs.follows = "nain4/nixpkgs";
+    nain4      .url     = "github:jacg/nain4";
+    nix-gl-host.url     = "github:numtide/nix-gl-host";
+    nosys      .follows = "nain4/nosys";
+    nixpkgs    .follows = "nain4/nixpkgs";
   };
 
   outputs = inputs @ {

--- a/templates/basic/flake/outputs.nix
+++ b/templates/basic/flake/outputs.nix
@@ -1,11 +1,13 @@
 { self
 , nixpkgs # <---- This `nixpkgs` has systems removed e.g. legacyPackages.zlib
 , nain4
+, nix-gl-host
 , ...
 }: let
   inherit (nixpkgs.legacyPackages) pkgs;
   inherit (import ./helpers.nix {inherit pkgs;}) shell-shared;
   inherit (nain4.deps) args-from-cli make-app;
+  nixglhost = nix-gl-host.defaultPackage;
   in {
 
     packages.default = self.packages.CHANGEME-PACKAGE;
@@ -37,13 +39,13 @@
     # Activated by `nix develop <URL to this flake>#clang`
     devShells.clang = pkgs.mkShell.override { stdenv = nain4.packages.clang_16.stdenv; } (shell-shared // {
       name = "CHANGEME-PROJECT-NAME-clang-devenv";
-      packages = nain4.deps.dev-shell-packages ++ [ nain4.packages.clang_16 ];
+      packages = nain4.deps.dev-shell-packages ++ [ nixglhost nain4.packages.clang_16 ];
     });
 
     # Activated by `nix develop <URL to this flake>#gcc`
     devShells.gcc = pkgs.mkShell (shell-shared // {
       name = "CHANGEME-PROJECT-NAME-gcc-devenv";
-      packages = nain4.deps.dev-shell-packages;
+      packages = nain4.deps.dev-shell-packages ++ [ nixglhost ];
     });
 
     # 1. `nix build` .#singularity

--- a/templates/basic/justfile
+++ b/templates/basic/justfile
@@ -57,3 +57,6 @@ run *ARGS: install
 
 clean:
   rm build install -rf
+
+host *ARGS: install
+  nixglhost install/CHANGEME-PROJECT-NAME/bin/CHANGEME-EXE -- -g "$@"


### PR DESCRIPTION
Just a branch with the necessary setup to test nix-gl-host, for future reference. Usage:

```
# on a non-NixOs, non-macOS machine:
nix run "github:gonzaponte/nain4?ref=nix-gl-host#boostrap-client-project" deleteme pname "description"
nix develop -c ./deleteme# -- just host
```