### PR TITLE
Test setup hook in bootstrap project

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -106,6 +106,20 @@ jobs:
           grep QT_QPA_PLATFORM_PLUGIN_PATH my-project-env
           echo ===============================================
 
+      - name: Test variables set by bootstrap project
+        run: |
+          nix develop ~/work/my-project# -c env > my-project-env
+          var="name_chosen_by_me_lib_PATH"
+          echo ====== checking that $var exits =========================
+          grep "name_chosen_by_me" my-project-env
+          echo =========================================================
+          echo ====== grepping LD_LIBRARY_PATH for $libpath ============
+          grep "LD_LIBRARY_PATH=" my-project-env | grep "name-chosen-by-me"
+          echo =========================================================
+          echo ====== grepping PKG_CONFIG_PATH for $libpath ============
+          grep "PKG_CONFIG_PATH=" my-project-env | grep "name-chosen-by-me"
+          echo =========================================================
+
       - name: Check that mdbook ANCHORs have been stripped from bootstrapped project
         run: |
           nix profile install nixpkgs#ripgrep

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,7 +9,7 @@ on:
       - docs
 
 jobs:
-  build-and-test:
+  build-and-test-bootstrap-project:
 
     # See https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
     if: (! contains(github.event.head_commit.message, '[skip ci]')                   &&

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build and test nain4 package
 on:
   pull_request:
   push:
@@ -9,7 +9,7 @@ on:
       - docs
 
 jobs:
-  build-and-test:
+  build-and-test-nain4-package:
 
     # See https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
     if: (! contains(github.event.head_commit.message, '[skip ci]')                   &&


### PR DESCRIPTION
We were checking that the shell variables from `nain4` were present in the dev-shell of the bootstrap project. Now, we also check for the project's own variables.

I've also taken the opportunity to rename the jobs to spot them more easily.